### PR TITLE
Fix merging of cells with `Multiline` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [2.0.2] - 2024-09-16
+
+- Fixed issue where cells would not merge if they stored a `Multiline` value [#29](https://github.com/PumasAI/SummaryTables.jl/pull/29).
+
 ## [2.0.1] - 2024-09-16
 
 - Fixed incorrect order of column group keys in `summarytable` and `listingtable` when some row/col group combinations were missing [#25](https://github.com/PumasAI/SummaryTables.jl/pull/25).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SummaryTables"
 uuid = "6ce4ecf0-73a7-4ce3-9fb4-80ebfe887b60"
 authors = ["Julius <juliusk@pumas.ai>", "Mike <michael@pumas.ai>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/cells.jl
+++ b/src/cells.jl
@@ -258,9 +258,9 @@ A `Multiline` value may only be used as the top-level value of a cell, so
 `Cell(Multiline(...))` is allowed but `Cell(Concat(Multiline(...), ...))` is not.
 """
 struct Multiline
-    values::Vector{Any}
+    values::Tuple
+    Multiline(args...) = new(args)
 end
-Multiline(args...) = Multiline(Any[args...])
 
 """
     Concat(args...)
@@ -532,7 +532,7 @@ end
 apply_rounder(x, r::Rounder) = x
 apply_rounder(x::AbstractFloat, r::Rounder) = RoundedFloat(x, r.round_digits, r.round_mode, r.trailing_zeros)
 apply_rounder(x::Concat, r::Rounder) = Concat(map(arg -> apply_rounder(arg, r), x.args)...)
-apply_rounder(x::Multiline, r::Rounder) = Multiline(map(arg -> apply_rounder(arg, r), x.values))
+apply_rounder(x::Multiline, r::Rounder) = Multiline(map(arg -> apply_rounder(arg, r), x.values)...)
 apply_rounder(x::Annotated, r::Rounder) = Annotated(apply_rounder(x.value, r), x.annotation, x.label)
 
 function postprocess_cell(cell::Cell, r::Rounder)

--- a/test/references/merged_cells/custom_datatypes.latex.txt
+++ b/test/references/merged_cells/custom_datatypes.latex.txt
@@ -1,0 +1,25 @@
+\documentclass{article}
+\usepackage{threeparttable}
+\usepackage{multirow}
+\usepackage{booktabs}
+\begin{document}
+\begin{table}[!ht]
+\setlength\tabcolsep{0pt}
+\centering
+\begin{threeparttable}
+\begin{tabular}{@{\extracolsep{2ex}}*{2}{cc}}
+\toprule
+\multicolumn{2}{c}{\begin{tabular}{@{}c@{}}A \\ B\end{tabular}} \\
+\multicolumn{2}{c}{\textsuperscript{Sup}} \\
+\multicolumn{2}{c}{\textsubscript{Sub}} \\
+\multicolumn{2}{c}{AB} \\
+\multicolumn{2}{c}{Label\tnote{1}} \\
+\bottomrule
+\end{tabular}
+\begin{tablenotes}[flushleft,para]
+\footnotesize
+\item[1]Annotation
+\end{tablenotes}
+\end{threeparttable}
+\end{table}
+\end{document}

--- a/test/references/merged_cells/custom_datatypes.txt
+++ b/test/references/merged_cells/custom_datatypes.txt
@@ -1,0 +1,49 @@
+<table class="st-0d1e8685">
+    <style>
+        .st-0d1e8685 {
+            border: none;
+            margin: 0 auto;
+            padding: 0.25rem;
+            border-collapse: separate;
+            border-spacing: 0.85em 0.2em;
+            line-height: 1.2em;
+        }
+
+        .st-0d1e8685 tr td {
+            vertical-align: top;
+            padding: 0;
+            border: none;
+        }
+
+        .st-0d1e8685 br {
+            line-height: 0em;
+            margin: 0;
+        }
+
+        .st-0d1e8685 sub {
+            line-height: 0;
+        }
+
+        .st-0d1e8685 sup {
+            line-height: 0;
+        }
+    </style>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr>
+        <td colspan="2" style="text-align:center;">A<br>B</td>
+    </tr>
+    <tr>
+        <td colspan="2" style="text-align:center;"><sup>Sup</sup></td>
+    </tr>
+    <tr>
+        <td colspan="2" style="text-align:center;"><sub>Sub</sub></td>
+    </tr>
+    <tr>
+        <td colspan="2" style="text-align:center;">AB</td>
+    </tr>
+    <tr>
+        <td colspan="2" style="text-align:center;">Label<sup>1</sup></td>
+    </tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="font-size: 0.8em;"><sup>1</sup> Annotation</td></tr>
+</table>

--- a/test/references/merged_cells/custom_datatypes.typ.txt
+++ b/test/references/merged_cells/custom_datatypes.typ.txt
@@ -1,0 +1,16 @@
+
+#table(
+    rows: 5,
+    columns: 2,
+    column-gutter: 0.25em,
+    align: (center, center),
+    stroke: none,
+    table.hline(y: 0, stroke: 1pt),
+    table.cell(colspan: 2)[A #linebreak() B],
+    table.cell(colspan: 2)[#super[Sup]],
+    table.cell(colspan: 2)[#sub[Sub]],
+    table.cell(colspan: 2)[AB],
+    table.cell(colspan: 2)[Label#super[1]],
+    table.hline(y: 5, stroke: 1pt),
+    table.cell(align: left, colspan: 2)[#super[1]#text(size: 0.8em)[Annotation]],
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -586,6 +586,19 @@ end
             reftest(t, "references/character_escaping/problematic_characters")
         end
 
+        @testset "Merged cells with special values" begin
+            contents = [
+                Multiline("A", "B"),
+                Superscript("Sup"),
+                Subscript("Sub"),
+                Concat("A", "B"),
+                Annotated("Label", "Annotation"),
+            ]
+            cells = Cell.(contents, merge = true)
+            t = Table(hcat(cells, cells))
+            reftest(t, "references/merged_cells/custom_datatypes")
+        end
+
         @testset "Styles" begin
             cells = [
                 SpannedCell(1, 1, "Row 1"),


### PR DESCRIPTION
Multiline cells would not actually merge because of struct equality rules, using a tuple like Concat avoids this issue without defining custom equality.