### PR TITLE
HTML dark mode compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+- Made HTML tables dark mode compatible by reusing foreground color for the lines [#62](https://github.com/PumasAI/SummaryTables.jl/pull/62).
+
 ## 3.0.2 - 2024-11-27
 
-- Add extra escape characters to Typst [#54](https://github.com/PumasAI/SummaryTables.jl/pull/54).
+- Added extra escape characters to Typst [#54](https://github.com/PumasAI/SummaryTables.jl/pull/54).
 
 ## 3.0.1 - 2024-10-24
 

--- a/src/html.jl
+++ b/src/html.jl
@@ -49,7 +49,7 @@ function Base.show(io::IO, ::MIME"text/html", ct::Table)
         </style>
     """)
     # border-collapse requires a separate row/cell to insert a border, it can't be put on <tfoot>
-    println(_io, "    <tr><td colspan=\"$(size(matrix, 2))\" style=\"border-bottom: 1.5px solid black; padding: 0\"></td></tr>")
+    println(_io, "    <tr><td colspan=\"$(size(matrix, 2))\" style=\"border-bottom: 1.5px solid currentColor; padding: 0\"></td></tr>")
 
     validate_rowgaps(ct.rowgaps, size(matrix, 1))
     validate_colgaps(ct.colgaps, size(matrix, 2))
@@ -61,7 +61,7 @@ function Base.show(io::IO, ::MIME"text/html", ct::Table)
         if row == ct.footer
             print(_io, "    <tfoot>\n")
             # border-collapse requires a separate row/cell to insert a border, it can't be put on <tfoot>
-            print(_io, "        <tr><td colspan=\"$(size(matrix, 2))\" style=\"border-bottom:1px solid black;padding:0\"></td></tr>")
+            print(_io, "        <tr><td colspan=\"$(size(matrix, 2))\" style=\"border-bottom:1px solid currentColor;padding:0\"></td></tr>")
         end
         print(_io, "    <tr>\n")
         for col in 1:size(matrix, 2)
@@ -80,12 +80,12 @@ function Base.show(io::IO, ::MIME"text/html", ct::Table)
         print(_io, "    </tr>\n")
         if row == ct.header
             # border-collapse requires a separate row/cell to insert a border, it can't be put on <thead>
-            print(_io, "        <tr><td colspan=\"$(size(matrix, 2))\" style=\"border-bottom:1px solid black;padding:0\"></td></tr>")
+            print(_io, "        <tr><td colspan=\"$(size(matrix, 2))\" style=\"border-bottom:1px solid currentColor;padding:0\"></td></tr>")
         end
     end
 
     # border-collapse requires a separate row/cell to insert a border, it can't be put on <tfoot>
-    println(_io, "    <tr><td colspan=\"$(size(matrix, 2))\" style=\"border-bottom: 1.5px solid black; padding: 0\"></td></tr>")
+    println(_io, "    <tr><td colspan=\"$(size(matrix, 2))\" style=\"border-bottom: 1.5px solid currentColor; padding: 0\"></td></tr>")
 
     if !isempty(annotations) || !isempty(ct.footnotes)
         print(_io, "    <tr><td colspan=\"$(size(matrix, 2))\" style=\"font-size: 0.8em;\">")
@@ -183,7 +183,7 @@ function print_html_cell(io, cell::SpannedCell, rowgaps, colgaps)
         print(io, "padding-right:$(padding_right/2)pt;")
     end
     if cell.style.border_bottom
-        print(io, "border-bottom:1px solid black; ")
+        print(io, "border-bottom:1px solid currentColor; ")
     end
     padding_bottom = get(rowgaps, cell.span[1].stop, nothing)
     if padding_bottom !== nothing

--- a/test/references/annotations/annotated_float.txt
+++ b/test/references/annotations/annotated_float.txt
@@ -1,6 +1,6 @@
-<table class="st-f42cb06e">
+<table class="st-395962c2">
     <style>
-        .st-f42cb06e {
+        .st-395962c2 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-f42cb06e tr td {
+        .st-395962c2 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-f42cb06e br {
+        .st-395962c2 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-f42cb06e sub {
+        .st-395962c2 sub {
             line-height: 0;
         }
 
-        .st-f42cb06e sup {
+        .st-395962c2 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="1" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="1" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">0.124<sup>A</sup></td>
     </tr>
-    <tr><td colspan="1" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="1" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="1" style="font-size: 0.8em;"><sup>A</sup> Note 1</td></tr>
 </table>

--- a/test/references/annotations/automatic_annotations.txt
+++ b/test/references/annotations/automatic_annotations.txt
@@ -1,6 +1,6 @@
-<table class="st-11d3bcb5">
+<table class="st-f9fe32b0">
     <style>
-        .st-11d3bcb5 {
+        .st-f9fe32b0 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-11d3bcb5 tr td {
+        .st-f9fe32b0 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-11d3bcb5 br {
+        .st-f9fe32b0 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-11d3bcb5 sub {
+        .st-f9fe32b0 sub {
             line-height: 0;
         }
 
-        .st-11d3bcb5 sup {
+        .st-f9fe32b0 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">A<sup>1</sup></td>
         <td style="text-align:center;">B<sup>2</sup></td>
@@ -37,6 +37,6 @@
         <td style="text-align:center;">C<sup>3</sup></td>
         <td style="text-align:center;">D<sup>1</sup></td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="2" style="font-size: 0.8em;"><sup>1</sup> Note 1<br/><sup>2</sup> Note 2<br/><sup>3</sup> Note 3</td></tr>
 </table>

--- a/test/references/annotations/manual_annotations.txt
+++ b/test/references/annotations/manual_annotations.txt
@@ -1,6 +1,6 @@
-<table class="st-926b343b">
+<table class="st-df15be76">
     <style>
-        .st-926b343b {
+        .st-df15be76 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-926b343b tr td {
+        .st-df15be76 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-926b343b br {
+        .st-df15be76 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-926b343b sub {
+        .st-df15be76 sub {
             line-height: 0;
         }
 
-        .st-926b343b sup {
+        .st-df15be76 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">A<sup>X</sup></td>
         <td style="text-align:center;">B<sup>Y</sup></td>
@@ -37,6 +37,6 @@
         <td style="text-align:center;">C<sup>1</sup></td>
         <td style="text-align:center;">D<sup>2</sup></td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="2" style="font-size: 0.8em;"><sup>1</sup> Note 3<br/><sup>2</sup> Note 4<br/><sup>X</sup> Note 1<br/><sup>Y</sup> Note 2</td></tr>
 </table>

--- a/test/references/character_escaping/problematic_characters.txt
+++ b/test/references/character_escaping/problematic_characters.txt
@@ -1,6 +1,6 @@
-<table class="st-10cadcb1">
+<table class="st-900727ee">
     <style>
-        .st-10cadcb1 {
+        .st-900727ee {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,28 +9,28 @@
             line-height: 1.2em;
         }
 
-        .st-10cadcb1 tr td {
+        .st-900727ee tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-10cadcb1 br {
+        .st-900727ee br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-10cadcb1 sub {
+        .st-900727ee sub {
             line-height: 0;
         }
 
-        .st-10cadcb1 sup {
+        .st-900727ee sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="1" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="1" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">&amp; % $ # _ { } ~ ^ \\ &lt; &gt; &quot; &apos; @ `</td>
     </tr>
-    <tr><td colspan="1" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="1" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/auto_false_1.txt
+++ b/test/references/global_rounding/auto_false_1.txt
@@ -1,6 +1,6 @@
-<table class="st-862f758f">
+<table class="st-a670f4a5">
     <style>
-        .st-862f758f {
+        .st-a670f4a5 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-862f758f tr td {
+        .st-a670f4a5 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-862f758f br {
+        .st-a670f4a5 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-862f758f sub {
+        .st-a670f4a5 sub {
             line-height: 0;
         }
 
-        .st-862f758f sup {
+        .st-a670f4a5 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">1.0e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1 &amp; 0.001</td>
         <td style="text-align:center;">1<br>0.001</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/auto_false_3.txt
+++ b/test/references/global_rounding/auto_false_3.txt
@@ -1,6 +1,6 @@
-<table class="st-e9b63b85">
+<table class="st-6f134c9a">
     <style>
-        .st-e9b63b85 {
+        .st-6f134c9a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-e9b63b85 tr td {
+        .st-6f134c9a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-e9b63b85 br {
+        .st-6f134c9a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-e9b63b85 sub {
+        .st-6f134c9a sub {
             line-height: 0;
         }
 
-        .st-e9b63b85 sup {
+        .st-6f134c9a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.41</td>
         <td style="text-align:center;">1.24e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.23 &amp; 0.00123</td>
         <td style="text-align:center;">1.23<br>0.00123</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/auto_true_1.txt
+++ b/test/references/global_rounding/auto_true_1.txt
@@ -1,6 +1,6 @@
-<table class="st-2d758f8a">
+<table class="st-073b937a">
     <style>
-        .st-2d758f8a {
+        .st-073b937a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-2d758f8a tr td {
+        .st-073b937a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-2d758f8a br {
+        .st-073b937a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-2d758f8a sub {
+        .st-073b937a sub {
             line-height: 0;
         }
 
-        .st-2d758f8a sup {
+        .st-073b937a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.0</td>
         <td style="text-align:center;">1.0e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.0 &amp; 0.001</td>
         <td style="text-align:center;">1.0<br>0.001</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/auto_true_3.txt
+++ b/test/references/global_rounding/auto_true_3.txt
@@ -1,6 +1,6 @@
-<table class="st-e9b63b85">
+<table class="st-6f134c9a">
     <style>
-        .st-e9b63b85 {
+        .st-6f134c9a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-e9b63b85 tr td {
+        .st-6f134c9a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-e9b63b85 br {
+        .st-6f134c9a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-e9b63b85 sub {
+        .st-6f134c9a sub {
             line-height: 0;
         }
 
-        .st-e9b63b85 sup {
+        .st-6f134c9a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.41</td>
         <td style="text-align:center;">1.24e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.23 &amp; 0.00123</td>
         <td style="text-align:center;">1.23<br>0.00123</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/default.txt
+++ b/test/references/global_rounding/default.txt
@@ -1,6 +1,6 @@
-<table class="st-e9b63b85">
+<table class="st-6f134c9a">
     <style>
-        .st-e9b63b85 {
+        .st-6f134c9a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-e9b63b85 tr td {
+        .st-6f134c9a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-e9b63b85 br {
+        .st-6f134c9a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-e9b63b85 sub {
+        .st-6f134c9a sub {
             line-height: 0;
         }
 
-        .st-e9b63b85 sup {
+        .st-6f134c9a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.41</td>
         <td style="text-align:center;">1.24e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.23 &amp; 0.00123</td>
         <td style="text-align:center;">1.23<br>0.00123</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/digits_false_1.txt
+++ b/test/references/global_rounding/digits_false_1.txt
@@ -1,6 +1,6 @@
-<table class="st-e9fb2e76">
+<table class="st-957b7621">
     <style>
-        .st-e9fb2e76 {
+        .st-957b7621 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-e9fb2e76 tr td {
+        .st-957b7621 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-e9fb2e76 br {
+        .st-957b7621 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-e9fb2e76 sub {
+        .st-957b7621 sub {
             line-height: 0;
         }
 
-        .st-e9fb2e76 sup {
+        .st-957b7621 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.4</td>
         <td style="text-align:center;">12352131</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.2 &amp; 0</td>
         <td style="text-align:center;">1.2<br>0</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/digits_false_3.txt
+++ b/test/references/global_rounding/digits_false_3.txt
@@ -1,6 +1,6 @@
-<table class="st-d2507538">
+<table class="st-e4b72430">
     <style>
-        .st-d2507538 {
+        .st-e4b72430 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-d2507538 tr td {
+        .st-e4b72430 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-d2507538 br {
+        .st-e4b72430 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-d2507538 sub {
+        .st-e4b72430 sub {
             line-height: 0;
         }
 
-        .st-d2507538 sup {
+        .st-e4b72430 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.414</td>
         <td style="text-align:center;">12352131</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.235 &amp; 0.001</td>
         <td style="text-align:center;">1.235<br>0.001</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/digits_true_1.txt
+++ b/test/references/global_rounding/digits_true_1.txt
@@ -1,6 +1,6 @@
-<table class="st-de9b531d">
+<table class="st-ff55dbb2">
     <style>
-        .st-de9b531d {
+        .st-ff55dbb2 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-de9b531d tr td {
+        .st-ff55dbb2 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-de9b531d br {
+        .st-ff55dbb2 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-de9b531d sub {
+        .st-ff55dbb2 sub {
             line-height: 0;
         }
 
-        .st-de9b531d sup {
+        .st-ff55dbb2 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.4</td>
         <td style="text-align:center;">12352131.0</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.2 &amp; 0.0</td>
         <td style="text-align:center;">1.2<br>0.0</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/digits_true_3.txt
+++ b/test/references/global_rounding/digits_true_3.txt
@@ -1,6 +1,6 @@
-<table class="st-7b5a179a">
+<table class="st-3b0616ef">
     <style>
-        .st-7b5a179a {
+        .st-3b0616ef {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-7b5a179a tr td {
+        .st-3b0616ef tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-7b5a179a br {
+        .st-3b0616ef br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-7b5a179a sub {
+        .st-3b0616ef sub {
             line-height: 0;
         }
 
-        .st-7b5a179a sup {
+        .st-3b0616ef sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.414</td>
         <td style="text-align:center;">12352131.000</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.235 &amp; 0.001</td>
         <td style="text-align:center;">1.235<br>0.001</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/no_rounding.txt
+++ b/test/references/global_rounding/no_rounding.txt
@@ -1,6 +1,6 @@
-<table class="st-2eee5af7">
+<table class="st-f298f9fb">
     <style>
-        .st-2eee5af7 {
+        .st-f298f9fb {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-2eee5af7 tr td {
+        .st-f298f9fb tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-2eee5af7 br {
+        .st-f298f9fb br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-2eee5af7 sub {
+        .st-f298f9fb sub {
             line-height: 0;
         }
 
-        .st-2eee5af7 sup {
+        .st-f298f9fb sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.4142135623730951</td>
         <td style="text-align:center;">1.2352131000001e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.23456 &amp; 0.0012345</td>
         <td style="text-align:center;">1.23456<br>0.0012345</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/sigdigits_false_1.txt
+++ b/test/references/global_rounding/sigdigits_false_1.txt
@@ -1,6 +1,6 @@
-<table class="st-862f758f">
+<table class="st-a670f4a5">
     <style>
-        .st-862f758f {
+        .st-a670f4a5 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-862f758f tr td {
+        .st-a670f4a5 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-862f758f br {
+        .st-a670f4a5 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-862f758f sub {
+        .st-a670f4a5 sub {
             line-height: 0;
         }
 
-        .st-862f758f sup {
+        .st-a670f4a5 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">1.0e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1 &amp; 0.001</td>
         <td style="text-align:center;">1<br>0.001</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/sigdigits_false_3.txt
+++ b/test/references/global_rounding/sigdigits_false_3.txt
@@ -1,6 +1,6 @@
-<table class="st-e9b63b85">
+<table class="st-6f134c9a">
     <style>
-        .st-e9b63b85 {
+        .st-6f134c9a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-e9b63b85 tr td {
+        .st-6f134c9a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-e9b63b85 br {
+        .st-6f134c9a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-e9b63b85 sub {
+        .st-6f134c9a sub {
             line-height: 0;
         }
 
-        .st-e9b63b85 sup {
+        .st-6f134c9a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.41</td>
         <td style="text-align:center;">1.24e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.23 &amp; 0.00123</td>
         <td style="text-align:center;">1.23<br>0.00123</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/sigdigits_true_1.txt
+++ b/test/references/global_rounding/sigdigits_true_1.txt
@@ -1,6 +1,6 @@
-<table class="st-2d758f8a">
+<table class="st-073b937a">
     <style>
-        .st-2d758f8a {
+        .st-073b937a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-2d758f8a tr td {
+        .st-073b937a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-2d758f8a br {
+        .st-073b937a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-2d758f8a sub {
+        .st-073b937a sub {
             line-height: 0;
         }
 
-        .st-2d758f8a sup {
+        .st-073b937a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.0</td>
         <td style="text-align:center;">1.0e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.0 &amp; 0.001</td>
         <td style="text-align:center;">1.0<br>0.001</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/global_rounding/sigdigits_true_3.txt
+++ b/test/references/global_rounding/sigdigits_true_3.txt
@@ -1,6 +1,6 @@
-<table class="st-e9b63b85">
+<table class="st-6f134c9a">
     <style>
-        .st-e9b63b85 {
+        .st-6f134c9a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-e9b63b85 tr td {
+        .st-6f134c9a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-e9b63b85 br {
+        .st-6f134c9a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-e9b63b85 sub {
+        .st-6f134c9a sub {
             line-height: 0;
         }
 
-        .st-e9b63b85 sup {
+        .st-6f134c9a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">1.41</td>
         <td style="text-align:center;">1.24e7</td>
@@ -41,5 +41,5 @@
         <td style="text-align:center;">1.23 &amp; 0.00123</td>
         <td style="text-align:center;">1.23<br>0.00123</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/cols_only.txt
+++ b/test/references/listingtable/cols_only.txt
@@ -1,6 +1,6 @@
-<table class="st-a6bdbaab">
+<table class="st-a383aeff">
     <style>
-        .st-a6bdbaab {
+        .st-a383aeff {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,36 +9,36 @@
             line-height: 1.2em;
         }
 
-        .st-a6bdbaab tr td {
+        .st-a383aeff tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-a6bdbaab br {
+        .st-a383aeff br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-a6bdbaab sub {
+        .st-a383aeff sub {
             line-height: 0;
         }
 
-        .st-a6bdbaab sup {
+        .st-a383aeff sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="8" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="8" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
-        <td colspan="8" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="8" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td colspan="4" style="text-align:center;">a</td>
         <td colspan="4" style="text-align:center;">b</td>
     </tr>
     <tr>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td colspan="2" style="text-align:center;">e</td>
@@ -47,10 +47,10 @@
         <td colspan="2" style="text-align:center;">f</td>
     </tr>
     <tr>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;">c</td>
@@ -65,7 +65,7 @@
     <tr>
         <td colspan="8" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="8" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="8" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">3</td>
         <td style="text-align:center;">2</td>
@@ -75,5 +75,5 @@
         <td style="text-align:center;">6</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="8" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="8" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/missing_groups.txt
+++ b/test/references/listingtable/missing_groups.txt
@@ -1,6 +1,6 @@
-<table class="st-cb1156a1">
+<table class="st-050ddbe4">
     <style>
-        .st-cb1156a1 {
+        .st-050ddbe4 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-cb1156a1 tr td {
+        .st-050ddbe4 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-cb1156a1 br {
+        .st-050ddbe4 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-cb1156a1 sub {
+        .st-050ddbe4 sub {
             line-height: 0;
         }
 
-        .st-cb1156a1 sup {
+        .st-050ddbe4 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">B</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">B</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -43,7 +43,7 @@
         <td style="font-weight:bold;text-align:left;">A</td>
         <td colspan="3" style="font-weight:bold;text-align:center;">value</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">&apos;a&apos;</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;">6</td>
@@ -61,5 +61,5 @@
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">3</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/natural_sort_order.txt
+++ b/test/references/listingtable/natural_sort_order.txt
@@ -1,6 +1,6 @@
-<table class="st-d45fe2ec">
+<table class="st-71eb7f84">
     <style>
-        .st-d45fe2ec {
+        .st-71eb7f84 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,32 +9,32 @@
             line-height: 1.2em;
         }
 
-        .st-d45fe2ec tr td {
+        .st-71eb7f84 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-d45fe2ec br {
+        .st-71eb7f84 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-d45fe2ec sub {
+        .st-71eb7f84 sub {
             line-height: 0;
         }
 
-        .st-d45fe2ec sup {
+        .st-71eb7f84 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="font-weight:bold;text-align:left;">id</td>
         <td style="font-weight:bold;text-align:left;">dose</td>
         <td style="font-weight:bold;text-align:center;">value</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">1</td>
         <td style="text-align:left;">1 mg</td>
         <td style="text-align:center;">5</td>
@@ -88,5 +88,5 @@
         <td style="text-align:left;">10 mg</td>
         <td style="text-align:center;">4</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/no_variable_header.txt
+++ b/test/references/listingtable/no_variable_header.txt
@@ -1,6 +1,6 @@
-<table class="st-a8a08bed">
+<table class="st-1b3a93ba">
     <style>
-        .st-a8a08bed {
+        .st-1b3a93ba {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-a8a08bed tr td {
+        .st-1b3a93ba tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-a8a08bed br {
+        .st-1b3a93ba br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-a8a08bed sub {
+        .st-1b3a93ba sub {
             line-height: 0;
         }
 
-        .st-a8a08bed sup {
+        .st-1b3a93ba sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -40,8 +40,8 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="font-weight:bold;text-align:left;">group1</td>
@@ -50,7 +50,7 @@
         <td style="text-align:center;">c</td>
         <td style="text-align:center;">d</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">a</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">3</td>
@@ -64,5 +64,5 @@
         <td style="text-align:center;">6</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/one_row_two_cols.txt
+++ b/test/references/listingtable/one_row_two_cols.txt
@@ -1,6 +1,6 @@
-<table class="st-e46cf0a9">
+<table class="st-40c005c1">
     <style>
-        .st-e46cf0a9 {
+        .st-40c005c1 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-e46cf0a9 tr td {
+        .st-40c005c1 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-e46cf0a9 br {
+        .st-40c005c1 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-e46cf0a9 sub {
+        .st-40c005c1 sub {
             line-height: 0;
         }
 
-        .st-e46cf0a9 sup {
+        .st-40c005c1 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -40,8 +40,8 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -54,7 +54,7 @@
         <td style="font-weight:bold;text-align:left;">group1</td>
         <td colspan="4" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">a</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">3</td>
@@ -68,5 +68,5 @@
         <td style="text-align:center;">6</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_cols=1_1.txt
+++ b/test/references/listingtable/pagination_cols=1_1.txt
@@ -1,6 +1,6 @@
-<table class="st-91fea6eb">
+<table class="st-6c786413">
     <style>
-        .st-91fea6eb {
+        .st-6c786413 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-91fea6eb tr td {
+        .st-6c786413 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-91fea6eb br {
+        .st-6c786413 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-91fea6eb sub {
+        .st-6c786413 sub {
             line-height: 0;
         }
 
-        .st-91fea6eb sup {
+        .st-6c786413 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">group1</td>
@@ -49,7 +49,7 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">1</td>
     </tr>
@@ -57,5 +57,5 @@
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">3</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_cols=1_2.txt
+++ b/test/references/listingtable/pagination_cols=1_2.txt
@@ -1,6 +1,6 @@
-<table class="st-6fcca3db">
+<table class="st-cc2ef13d">
     <style>
-        .st-6fcca3db {
+        .st-cc2ef13d {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-6fcca3db tr td {
+        .st-cc2ef13d tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-6fcca3db br {
+        .st-cc2ef13d br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-6fcca3db sub {
+        .st-cc2ef13d sub {
             line-height: 0;
         }
 
-        .st-6fcca3db sup {
+        .st-cc2ef13d sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">group1</td>
@@ -49,7 +49,7 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">2</td>
     </tr>
@@ -57,5 +57,5 @@
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">4</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_cols=1_3.txt
+++ b/test/references/listingtable/pagination_cols=1_3.txt
@@ -1,6 +1,6 @@
-<table class="st-2fe4e7af">
+<table class="st-c82728a8">
     <style>
-        .st-2fe4e7af {
+        .st-c82728a8 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-2fe4e7af tr td {
+        .st-c82728a8 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-2fe4e7af br {
+        .st-c82728a8 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-2fe4e7af sub {
+        .st-c82728a8 sub {
             line-height: 0;
         }
 
-        .st-2fe4e7af sup {
+        .st-c82728a8 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">group1</td>
@@ -49,7 +49,7 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">5</td>
     </tr>
@@ -57,5 +57,5 @@
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">7</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_cols=1_4.txt
+++ b/test/references/listingtable/pagination_cols=1_4.txt
@@ -1,6 +1,6 @@
-<table class="st-d1862e53">
+<table class="st-b5608d55">
     <style>
-        .st-d1862e53 {
+        .st-b5608d55 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-d1862e53 tr td {
+        .st-b5608d55 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-d1862e53 br {
+        .st-b5608d55 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-d1862e53 sub {
+        .st-b5608d55 sub {
             line-height: 0;
         }
 
-        .st-d1862e53 sup {
+        .st-b5608d55 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">group1</td>
@@ -49,7 +49,7 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">6</td>
     </tr>
@@ -57,5 +57,5 @@
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_cols=2_1.txt
+++ b/test/references/listingtable/pagination_cols=2_1.txt
@@ -1,6 +1,6 @@
-<table class="st-4f55741c">
+<table class="st-331a3ced">
     <style>
-        .st-4f55741c {
+        .st-331a3ced {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-4f55741c tr td {
+        .st-331a3ced tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-4f55741c br {
+        .st-331a3ced br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-4f55741c sub {
+        .st-331a3ced sub {
             line-height: 0;
         }
 
-        .st-4f55741c sup {
+        .st-331a3ced sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -50,7 +50,7 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
@@ -60,5 +60,5 @@
         <td style="text-align:center;">3</td>
         <td style="text-align:center;">4</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_cols=2_2.txt
+++ b/test/references/listingtable/pagination_cols=2_2.txt
@@ -1,6 +1,6 @@
-<table class="st-2cf404e4">
+<table class="st-25cb1e53">
     <style>
-        .st-2cf404e4 {
+        .st-25cb1e53 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-2cf404e4 tr td {
+        .st-25cb1e53 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-2cf404e4 br {
+        .st-25cb1e53 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-2cf404e4 sub {
+        .st-25cb1e53 sub {
             line-height: 0;
         }
 
-        .st-2cf404e4 sup {
+        .st-25cb1e53 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -50,7 +50,7 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">5</td>
         <td style="text-align:center;">6</td>
@@ -60,5 +60,5 @@
         <td style="text-align:center;">7</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=1_1.txt
+++ b/test/references/listingtable/pagination_rows=1_1.txt
@@ -1,6 +1,6 @@
-<table class="st-1d7f929f">
+<table class="st-34cfc499">
     <style>
-        .st-1d7f929f {
+        .st-34cfc499 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-1d7f929f tr td {
+        .st-34cfc499 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-1d7f929f br {
+        .st-34cfc499 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-1d7f929f sub {
+        .st-34cfc499 sub {
             line-height: 0;
         }
 
-        .st-1d7f929f sup {
+        .st-34cfc499 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,11 +45,11 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">a</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">3</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=1_2.txt
+++ b/test/references/listingtable/pagination_rows=1_2.txt
@@ -1,6 +1,6 @@
-<table class="st-125ae1e5">
+<table class="st-2e47b73a">
     <style>
-        .st-125ae1e5 {
+        .st-2e47b73a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-125ae1e5 tr td {
+        .st-2e47b73a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-125ae1e5 br {
+        .st-2e47b73a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-125ae1e5 sub {
+        .st-2e47b73a sub {
             line-height: 0;
         }
 
-        .st-125ae1e5 sup {
+        .st-2e47b73a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,11 +45,11 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">a</td>
         <td style="text-align:left;">f</td>
         <td style="text-align:center;">2</td>
         <td style="text-align:center;">4</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=1_3.txt
+++ b/test/references/listingtable/pagination_rows=1_3.txt
@@ -1,6 +1,6 @@
-<table class="st-b397cf59">
+<table class="st-f0a9c42e">
     <style>
-        .st-b397cf59 {
+        .st-f0a9c42e {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-b397cf59 tr td {
+        .st-f0a9c42e tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-b397cf59 br {
+        .st-f0a9c42e br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-b397cf59 sub {
+        .st-f0a9c42e sub {
             line-height: 0;
         }
 
-        .st-b397cf59 sup {
+        .st-f0a9c42e sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,11 +45,11 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">b</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">5</td>
         <td style="text-align:center;">7</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=1_4.txt
+++ b/test/references/listingtable/pagination_rows=1_4.txt
@@ -1,6 +1,6 @@
-<table class="st-6b458619">
+<table class="st-ad3aede1">
     <style>
-        .st-6b458619 {
+        .st-ad3aede1 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-6b458619 tr td {
+        .st-ad3aede1 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-6b458619 br {
+        .st-ad3aede1 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-6b458619 sub {
+        .st-ad3aede1 sub {
             line-height: 0;
         }
 
-        .st-6b458619 sup {
+        .st-ad3aede1 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,11 +45,11 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">b</td>
         <td style="text-align:left;">f</td>
         <td style="text-align:center;">6</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=1_cols=2_1.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_1.txt
@@ -1,6 +1,6 @@
-<table class="st-f5558740">
+<table class="st-1b0701b8">
     <style>
-        .st-f5558740 {
+        .st-1b0701b8 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-f5558740 tr td {
+        .st-1b0701b8 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-f5558740 br {
+        .st-1b0701b8 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-f5558740 sub {
+        .st-1b0701b8 sub {
             line-height: 0;
         }
 
-        .st-f5558740 sup {
+        .st-1b0701b8 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -50,10 +50,10 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=1_cols=2_2.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_2.txt
@@ -1,6 +1,6 @@
-<table class="st-49405443">
+<table class="st-c0824370">
     <style>
-        .st-49405443 {
+        .st-c0824370 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-49405443 tr td {
+        .st-c0824370 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-49405443 br {
+        .st-c0824370 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-49405443 sub {
+        .st-c0824370 sub {
             line-height: 0;
         }
 
-        .st-49405443 sup {
+        .st-c0824370 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -50,10 +50,10 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">5</td>
         <td style="text-align:center;">6</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=1_cols=2_3.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_3.txt
@@ -1,6 +1,6 @@
-<table class="st-9209a8dc">
+<table class="st-4066ae2a">
     <style>
-        .st-9209a8dc {
+        .st-4066ae2a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-9209a8dc tr td {
+        .st-4066ae2a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9209a8dc br {
+        .st-4066ae2a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9209a8dc sub {
+        .st-4066ae2a sub {
             line-height: 0;
         }
 
-        .st-9209a8dc sup {
+        .st-4066ae2a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -50,10 +50,10 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">3</td>
         <td style="text-align:center;">4</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=1_cols=2_4.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_4.txt
@@ -1,6 +1,6 @@
-<table class="st-a16d1ac2">
+<table class="st-76ae7861">
     <style>
-        .st-a16d1ac2 {
+        .st-76ae7861 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-a16d1ac2 tr td {
+        .st-76ae7861 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-a16d1ac2 br {
+        .st-76ae7861 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-a16d1ac2 sub {
+        .st-76ae7861 sub {
             line-height: 0;
         }
 
-        .st-a16d1ac2 sup {
+        .st-76ae7861 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -50,10 +50,10 @@
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">7</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_1.txt
+++ b/test/references/listingtable/pagination_rows=2_1.txt
@@ -1,6 +1,6 @@
-<table class="st-662c5634">
+<table class="st-f8cdf706">
     <style>
-        .st-662c5634 {
+        .st-f8cdf706 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-662c5634 tr td {
+        .st-f8cdf706 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-662c5634 br {
+        .st-f8cdf706 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-662c5634 sub {
+        .st-f8cdf706 sub {
             line-height: 0;
         }
 
-        .st-662c5634 sup {
+        .st-f8cdf706 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">a</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">1</td>
@@ -56,5 +56,5 @@
         <td style="text-align:center;">2</td>
         <td style="text-align:center;">4</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_2.txt
+++ b/test/references/listingtable/pagination_rows=2_2.txt
@@ -1,6 +1,6 @@
-<table class="st-93a09508">
+<table class="st-8331d7ad">
     <style>
-        .st-93a09508 {
+        .st-8331d7ad {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-93a09508 tr td {
+        .st-8331d7ad tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-93a09508 br {
+        .st-8331d7ad br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-93a09508 sub {
+        .st-8331d7ad sub {
             line-height: 0;
         }
 
-        .st-93a09508 sup {
+        .st-8331d7ad sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">b</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">5</td>
@@ -56,5 +56,5 @@
         <td style="text-align:center;">6</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_summarized_1.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_1.txt
@@ -1,6 +1,6 @@
-<table class="st-52b02cd4">
+<table class="st-69975943">
     <style>
-        .st-52b02cd4 {
+        .st-69975943 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-52b02cd4 tr td {
+        .st-69975943 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-52b02cd4 br {
+        .st-69975943 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-52b02cd4 sub {
+        .st-69975943 sub {
             line-height: 0;
         }
 
-        .st-52b02cd4 sup {
+        .st-69975943 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">a</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">1</td>
@@ -79,5 +79,5 @@
         <td style="text-align:center;">2.38</td>
         <td style="text-align:center;">2.38</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_1.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_1.txt
@@ -1,6 +1,6 @@
-<table class="st-9fb446ab">
+<table class="st-24a80705">
     <style>
-        .st-9fb446ab {
+        .st-24a80705 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-9fb446ab tr td {
+        .st-24a80705 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9fb446ab br {
+        .st-24a80705 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9fb446ab sub {
+        .st-24a80705 sub {
             line-height: 0;
         }
 
-        .st-9fb446ab sup {
+        .st-24a80705 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">parameters</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">parameters</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -46,7 +46,7 @@
         <td style="font-weight:bold;text-align:left;">group</td>
         <td colspan="3" style="font-weight:bold;text-align:center;">value</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">1</td>
         <td style="text-align:left;">1</td>
         <td style="text-align:center;">1</td>
@@ -72,5 +72,5 @@
         <td style="text-align:center;">8</td>
         <td style="text-align:center;">12</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_2.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_2.txt
@@ -1,6 +1,6 @@
-<table class="st-9fb446ab">
+<table class="st-24a80705">
     <style>
-        .st-9fb446ab {
+        .st-24a80705 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-9fb446ab tr td {
+        .st-24a80705 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9fb446ab br {
+        .st-24a80705 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9fb446ab sub {
+        .st-24a80705 sub {
             line-height: 0;
         }
 
-        .st-9fb446ab sup {
+        .st-24a80705 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">parameters</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">parameters</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -46,7 +46,7 @@
         <td style="font-weight:bold;text-align:left;">group</td>
         <td colspan="3" style="font-weight:bold;text-align:center;">value</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">1</td>
         <td style="text-align:left;">1</td>
         <td style="text-align:center;">1</td>
@@ -72,5 +72,5 @@
         <td style="text-align:center;">8</td>
         <td style="text-align:center;">12</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_1.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_1.txt
@@ -1,6 +1,6 @@
-<table class="st-6814f98f">
+<table class="st-1c4b15f6">
     <style>
-        .st-6814f98f {
+        .st-1c4b15f6 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-6814f98f tr td {
+        .st-1c4b15f6 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-6814f98f br {
+        .st-1c4b15f6 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-6814f98f sub {
+        .st-1c4b15f6 sub {
             line-height: 0;
         }
 
-        .st-6814f98f sup {
+        .st-1c4b15f6 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="padding-bottom: 3.0pt;text-align:left;">a</td>
         <td style="padding-bottom: 3.0pt;text-align:left;">e</td>
         <td style="padding-bottom: 3.0pt;text-align:center;">1</td>
@@ -63,5 +63,5 @@
         <td style="text-align:center;">NaN</td>
         <td style="text-align:center;">NaN</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_2.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_2.txt
@@ -1,6 +1,6 @@
-<table class="st-b50a5acf">
+<table class="st-c141df47">
     <style>
-        .st-b50a5acf {
+        .st-c141df47 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-b50a5acf tr td {
+        .st-c141df47 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-b50a5acf br {
+        .st-c141df47 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-b50a5acf sub {
+        .st-c141df47 sub {
             line-height: 0;
         }
 
-        .st-b50a5acf sup {
+        .st-c141df47 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="padding-bottom: 3.0pt;text-align:left;">a</td>
         <td style="padding-bottom: 3.0pt;text-align:left;">f</td>
         <td style="padding-bottom: 3.0pt;text-align:center;">2</td>
@@ -63,5 +63,5 @@
         <td style="text-align:center;">NaN</td>
         <td style="text-align:center;">NaN</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_3.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_3.txt
@@ -1,6 +1,6 @@
-<table class="st-3e1dcb08">
+<table class="st-99322dbd">
     <style>
-        .st-3e1dcb08 {
+        .st-99322dbd {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-3e1dcb08 tr td {
+        .st-99322dbd tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-3e1dcb08 br {
+        .st-99322dbd br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-3e1dcb08 sub {
+        .st-99322dbd sub {
             line-height: 0;
         }
 
-        .st-3e1dcb08 sup {
+        .st-99322dbd sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="padding-bottom: 3.0pt;text-align:left;">b</td>
         <td style="padding-bottom: 3.0pt;text-align:left;">e</td>
         <td style="padding-bottom: 3.0pt;text-align:center;">5</td>
@@ -63,5 +63,5 @@
         <td style="text-align:center;">NaN</td>
         <td style="text-align:center;">NaN</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_4.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_4.txt
@@ -1,6 +1,6 @@
-<table class="st-70e7e224">
+<table class="st-b2aa6a12">
     <style>
-        .st-70e7e224 {
+        .st-b2aa6a12 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-70e7e224 tr td {
+        .st-b2aa6a12 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-70e7e224 br {
+        .st-b2aa6a12 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-70e7e224 sub {
+        .st-b2aa6a12 sub {
             line-height: 0;
         }
 
-        .st-70e7e224 sup {
+        .st-b2aa6a12 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="padding-bottom: 3.0pt;text-align:left;">b</td>
         <td style="padding-bottom: 3.0pt;text-align:left;">f</td>
         <td style="padding-bottom: 3.0pt;text-align:center;">6</td>
@@ -63,5 +63,5 @@
         <td style="text-align:center;">NaN</td>
         <td style="text-align:center;">NaN</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/renaming.txt
+++ b/test/references/listingtable/renaming.txt
@@ -1,6 +1,6 @@
-<table class="st-fe59958c">
+<table class="st-24f42bad">
     <style>
-        .st-fe59958c {
+        .st-24f42bad {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-fe59958c tr td {
+        .st-24f42bad tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-fe59958c br {
+        .st-24f42bad br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-fe59958c sub {
+        .st-24f42bad sub {
             line-height: 0;
         }
 
-        .st-fe59958c sup {
+        .st-24f42bad sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">Group 3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">Group 3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">Group 2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">Value 1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">a</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">1</td>
@@ -79,5 +79,5 @@
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">3</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/rows_only.txt
+++ b/test/references/listingtable/rows_only.txt
@@ -1,6 +1,6 @@
-<table class="st-7f8f1f78">
+<table class="st-5924fd57">
     <style>
-        .st-7f8f1f78 {
+        .st-5924fd57 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,33 +9,33 @@
             line-height: 1.2em;
         }
 
-        .st-7f8f1f78 tr td {
+        .st-5924fd57 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-7f8f1f78 br {
+        .st-5924fd57 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-7f8f1f78 sub {
+        .st-5924fd57 sub {
             line-height: 0;
         }
 
-        .st-7f8f1f78 sup {
+        .st-5924fd57 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="font-weight:bold;text-align:left;">group1</td>
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="4" style="text-align:left;">a</td>
         <td rowspan="2" style="text-align:left;">e</td>
         <td style="text-align:left;">c</td>
@@ -73,5 +73,5 @@
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/sort_false.txt
+++ b/test/references/listingtable/sort_false.txt
@@ -1,6 +1,6 @@
-<table class="st-9fb446ab">
+<table class="st-24a80705">
     <style>
-        .st-9fb446ab {
+        .st-24a80705 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-9fb446ab tr td {
+        .st-24a80705 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9fb446ab br {
+        .st-24a80705 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9fb446ab sub {
+        .st-24a80705 sub {
             line-height: 0;
         }
 
-        .st-9fb446ab sup {
+        .st-24a80705 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">parameters</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">parameters</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -46,7 +46,7 @@
         <td style="font-weight:bold;text-align:left;">group</td>
         <td colspan="3" style="font-weight:bold;text-align:center;">value</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">1</td>
         <td style="text-align:left;">1</td>
         <td style="text-align:center;">1</td>
@@ -72,5 +72,5 @@
         <td style="text-align:center;">8</td>
         <td style="text-align:center;">12</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/summarize_end_cols_two_funcs.txt
+++ b/test/references/listingtable/summarize_end_cols_two_funcs.txt
@@ -1,6 +1,6 @@
-<table class="st-f05c5f2b">
+<table class="st-997c3f50">
     <style>
-        .st-f05c5f2b {
+        .st-997c3f50 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,29 +9,29 @@
             line-height: 1.2em;
         }
 
-        .st-f05c5f2b tr td {
+        .st-997c3f50 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-f05c5f2b br {
+        .st-997c3f50 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-f05c5f2b sub {
+        .st-997c3f50 sub {
             line-height: 0;
         }
 
-        .st-f05c5f2b sup {
+        .st-997c3f50 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="7" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
     </tr>
@@ -44,8 +44,8 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
     </tr>
@@ -64,7 +64,7 @@
         <td style="font-weight:bold;text-align:right;">mean</td>
         <td style="font-weight:bold;text-align:right;">std</td>
     </tr>
-        <tr><td colspan="7" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="7" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
@@ -82,5 +82,5 @@
         <td style="text-align:right;">5.5</td>
         <td style="text-align:right;">2.38</td>
     </tr>
-    <tr><td colspan="7" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/summarize_end_rows.txt
+++ b/test/references/listingtable/summarize_end_rows.txt
@@ -1,6 +1,6 @@
-<table class="st-9811cb9d">
+<table class="st-6c1e8de0">
     <style>
-        .st-9811cb9d {
+        .st-6c1e8de0 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-9811cb9d tr td {
+        .st-6c1e8de0 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9811cb9d br {
+        .st-6c1e8de0 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9811cb9d sub {
+        .st-6c1e8de0 sub {
             line-height: 0;
         }
 
-        .st-9811cb9d sup {
+        .st-6c1e8de0 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">a</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">1</td>
@@ -73,5 +73,5 @@
         <td style="padding-top: 3.0pt;text-align:center;">3.5</td>
         <td style="padding-top: 3.0pt;text-align:center;">5.5</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/summarize_end_rows_two_funcs.txt
+++ b/test/references/listingtable/summarize_end_rows_two_funcs.txt
@@ -1,6 +1,6 @@
-<table class="st-52b02cd4">
+<table class="st-69975943">
     <style>
-        .st-52b02cd4 {
+        .st-69975943 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-52b02cd4 tr td {
+        .st-69975943 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-52b02cd4 br {
+        .st-69975943 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-52b02cd4 sub {
+        .st-69975943 sub {
             line-height: 0;
         }
 
-        .st-52b02cd4 sup {
+        .st-69975943 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">a</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">1</td>
@@ -79,5 +79,5 @@
         <td style="text-align:center;">2.38</td>
         <td style="text-align:center;">2.38</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/summarize_first_group_cols.txt
+++ b/test/references/listingtable/summarize_first_group_cols.txt
@@ -1,6 +1,6 @@
-<table class="st-b8f2acd8">
+<table class="st-876de16e">
     <style>
-        .st-b8f2acd8 {
+        .st-876de16e {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-b8f2acd8 tr td {
+        .st-876de16e tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-b8f2acd8 br {
+        .st-876de16e br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-b8f2acd8 sub {
+        .st-876de16e sub {
             line-height: 0;
         }
 
-        .st-b8f2acd8 sup {
+        .st-876de16e sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="7" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
         <td style="text-align:center;"></td>
     </tr>
     <tr>
@@ -45,9 +45,9 @@
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
         <td style="text-align:center;"></td>
     </tr>
     <tr>
@@ -66,7 +66,7 @@
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
         <td style="font-weight:bold;text-align:right;">mean</td>
     </tr>
-        <tr><td colspan="7" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="7" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
@@ -84,5 +84,5 @@
         <td style="text-align:center;">8</td>
         <td style="text-align:right;">7.5</td>
     </tr>
-    <tr><td colspan="7" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/summarize_first_group_rows.txt
+++ b/test/references/listingtable/summarize_first_group_rows.txt
@@ -1,6 +1,6 @@
-<table class="st-4cca1e27">
+<table class="st-5b28db30">
     <style>
-        .st-4cca1e27 {
+        .st-5b28db30 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-4cca1e27 tr td {
+        .st-5b28db30 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-4cca1e27 br {
+        .st-5b28db30 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-4cca1e27 sub {
+        .st-5b28db30 sub {
             line-height: 0;
         }
 
-        .st-4cca1e27 sup {
+        .st-5b28db30 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="padding-bottom: 3.0pt;text-align:left;">a</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">1</td>
@@ -79,5 +79,5 @@
         <td style="padding-top: 3.0pt;text-align:center;">5.5</td>
         <td style="padding-top: 3.0pt;text-align:center;">7.5</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/summarize_last_group_cols.txt
+++ b/test/references/listingtable/summarize_last_group_cols.txt
@@ -1,6 +1,6 @@
-<table class="st-61c2b153">
+<table class="st-dba91966">
     <style>
-        .st-61c2b153 {
+        .st-dba91966 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-61c2b153 tr td {
+        .st-dba91966 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-61c2b153 br {
+        .st-dba91966 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-61c2b153 sub {
+        .st-dba91966 sub {
             line-height: 0;
         }
 
-        .st-61c2b153 sup {
+        .st-dba91966 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="9" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="9" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">group1</td>
@@ -84,7 +84,7 @@
         <td style="font-weight:bold;text-align:center;">value1</td>
         <td style="font-weight:bold;text-align:right;">mean</td>
     </tr>
-        <tr><td colspan="9" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="9" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:right;">1</td>
@@ -106,5 +106,5 @@
         <td style="text-align:center;">8</td>
         <td style="text-align:right;">8</td>
     </tr>
-    <tr><td colspan="9" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="9" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/summarize_last_group_rows.txt
+++ b/test/references/listingtable/summarize_last_group_rows.txt
@@ -1,6 +1,6 @@
-<table class="st-7c9c0c7d">
+<table class="st-142b8222">
     <style>
-        .st-7c9c0c7d {
+        .st-142b8222 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-7c9c0c7d tr td {
+        .st-142b8222 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-7c9c0c7d br {
+        .st-142b8222 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-7c9c0c7d sub {
+        .st-142b8222 sub {
             line-height: 0;
         }
 
-        .st-7c9c0c7d sup {
+        .st-142b8222 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="padding-bottom: 3.0pt;text-align:left;">a</td>
         <td style="padding-bottom: 3.0pt;text-align:left;">e</td>
         <td style="padding-bottom: 3.0pt;text-align:center;">1</td>
@@ -93,5 +93,5 @@
         <td style="padding-top: 3.0pt;text-align:center;">6</td>
         <td style="padding-top: 3.0pt;text-align:center;">8</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/two_rows_one_col.txt
+++ b/test/references/listingtable/two_rows_one_col.txt
@@ -1,6 +1,6 @@
-<table class="st-d2f10207">
+<table class="st-d3319677">
     <style>
-        .st-d2f10207 {
+        .st-d3319677 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-d2f10207 tr td {
+        .st-d3319677 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-d2f10207 br {
+        .st-d3319677 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-d2f10207 sub {
+        .st-d3319677 sub {
             line-height: 0;
         }
 
-        .st-d2f10207 sup {
+        .st-d3319677 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="font-weight:bold;text-align:left;">group2</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">a</td>
         <td style="text-align:left;">e</td>
         <td style="text-align:center;">1</td>
@@ -67,5 +67,5 @@
         <td style="text-align:center;">6</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/listingtable/two_same_summarizers.txt
+++ b/test/references/listingtable/two_same_summarizers.txt
@@ -1,6 +1,6 @@
-<table class="st-3a1d0d1d">
+<table class="st-06eaf25c">
     <style>
-        .st-3a1d0d1d {
+        .st-06eaf25c {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-3a1d0d1d tr td {
+        .st-06eaf25c tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-3a1d0d1d br {
+        .st-06eaf25c br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-3a1d0d1d sub {
+        .st-06eaf25c sub {
             line-height: 0;
         }
 
-        .st-3a1d0d1d sup {
+        .st-06eaf25c sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="font-weight:bold;text-align:left;">id</td>
         <td style="font-weight:bold;text-align:left;">dose</td>
@@ -36,7 +36,7 @@
         <td style="font-weight:bold;text-align:right;">mean</td>
         <td style="font-weight:bold;text-align:right;">mean</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">1</td>
         <td style="text-align:left;">1 mg</td>
         <td style="text-align:center;">5</td>
@@ -128,5 +128,5 @@
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_false.txt
+++ b/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_false.txt
@@ -1,6 +1,6 @@
-<table class="st-27581ac5">
+<table class="st-3639c57a">
     <style>
-        .st-27581ac5 {
+        .st-3639c57a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-27581ac5 tr td {
+        .st-3639c57a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-27581ac5 br {
+        .st-3639c57a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-27581ac5 sub {
+        .st-3639c57a sub {
             line-height: 0;
         }
 
-        .st-27581ac5 sup {
+        .st-3639c57a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">Cell 1<sup>1</sup></td>
         <td style="text-align:center;">Cell 2</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="2" style="font-size: 0.8em;"><sup>1</sup> Note 1&nbsp;&nbsp;&nbsp;&nbsp;First footnote.&nbsp;&nbsp;&nbsp;&nbsp;Second footnote.</td></tr>
 </table>

--- a/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_true.txt
+++ b/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_true.txt
@@ -1,6 +1,6 @@
-<table class="st-143ccd72">
+<table class="st-34878dbb">
     <style>
-        .st-143ccd72 {
+        .st-34878dbb {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-143ccd72 tr td {
+        .st-34878dbb tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-143ccd72 br {
+        .st-34878dbb br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-143ccd72 sub {
+        .st-34878dbb sub {
             line-height: 0;
         }
 
-        .st-143ccd72 sup {
+        .st-34878dbb sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">Cell 1<sup>1</sup></td>
         <td style="text-align:center;">Cell 2</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="2" style="font-size: 0.8em;"><sup>1</sup> Note 1<br/>First footnote.<br/>Second footnote.</td></tr>
 </table>

--- a/test/references/manual_footnotes/footnotes_linebreaks_false.txt
+++ b/test/references/manual_footnotes/footnotes_linebreaks_false.txt
@@ -1,6 +1,6 @@
-<table class="st-010c1796">
+<table class="st-70c955f8">
     <style>
-        .st-010c1796 {
+        .st-70c955f8 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-010c1796 tr td {
+        .st-70c955f8 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-010c1796 br {
+        .st-70c955f8 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-010c1796 sub {
+        .st-70c955f8 sub {
             line-height: 0;
         }
 
-        .st-010c1796 sup {
+        .st-70c955f8 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">Cell 1</td>
         <td style="text-align:center;">Cell 2</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="2" style="font-size: 0.8em;">First footnote.&nbsp;&nbsp;&nbsp;&nbsp;Second footnote.</td></tr>
 </table>

--- a/test/references/manual_footnotes/footnotes_linebreaks_true.txt
+++ b/test/references/manual_footnotes/footnotes_linebreaks_true.txt
@@ -1,6 +1,6 @@
-<table class="st-11c286f1">
+<table class="st-b69b1bb7">
     <style>
-        .st-11c286f1 {
+        .st-b69b1bb7 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-11c286f1 tr td {
+        .st-b69b1bb7 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-11c286f1 br {
+        .st-b69b1bb7 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-11c286f1 sub {
+        .st-b69b1bb7 sub {
             line-height: 0;
         }
 
-        .st-11c286f1 sup {
+        .st-b69b1bb7 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">Cell 1</td>
         <td style="text-align:center;">Cell 2</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="2" style="font-size: 0.8em;">First footnote.<br/>Second footnote.</td></tr>
 </table>

--- a/test/references/merged_cells/custom_datatypes.txt
+++ b/test/references/merged_cells/custom_datatypes.txt
@@ -1,6 +1,6 @@
-<table class="st-0d1e8685">
+<table class="st-6a23e29c">
     <style>
-        .st-0d1e8685 {
+        .st-6a23e29c {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-0d1e8685 tr td {
+        .st-6a23e29c tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-0d1e8685 br {
+        .st-6a23e29c br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-0d1e8685 sub {
+        .st-6a23e29c sub {
             line-height: 0;
         }
 
-        .st-0d1e8685 sup {
+        .st-6a23e29c sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td colspan="2" style="text-align:center;">A<br>B</td>
     </tr>
@@ -44,6 +44,6 @@
     <tr>
         <td colspan="2" style="text-align:center;">Label<sup>1</sup></td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="2" style="font-size: 0.8em;"><sup>1</sup> Annotation</td></tr>
 </table>

--- a/test/references/paginated_table_interactive.txt
+++ b/test/references/paginated_table_interactive.txt
@@ -27,9 +27,9 @@ Page 4
 <div>
 <div style="display:block">
 <h3>Page 1</h3>
-<table class="st-f5558740">
+<table class="st-1b0701b8">
     <style>
-        .st-f5558740 {
+        .st-1b0701b8 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -38,29 +38,29 @@ Page 4
             line-height: 1.2em;
         }
 
-        .st-f5558740 tr td {
+        .st-1b0701b8 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-f5558740 br {
+        .st-1b0701b8 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-f5558740 sub {
+        .st-1b0701b8 sub {
             line-height: 0;
         }
 
-        .st-f5558740 sup {
+        .st-1b0701b8 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -68,7 +68,7 @@ Page 4
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -79,19 +79,19 @@ Page 4
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>
 </div>
 <div style="display:none">
 <h3>Page 2</h3>
-<table class="st-49405443">
+<table class="st-c0824370">
     <style>
-        .st-49405443 {
+        .st-c0824370 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -100,29 +100,29 @@ Page 4
             line-height: 1.2em;
         }
 
-        .st-49405443 tr td {
+        .st-c0824370 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-49405443 br {
+        .st-c0824370 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-49405443 sub {
+        .st-c0824370 sub {
             line-height: 0;
         }
 
-        .st-49405443 sup {
+        .st-c0824370 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -130,7 +130,7 @@ Page 4
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -141,19 +141,19 @@ Page 4
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">c</td>
         <td style="text-align:center;">5</td>
         <td style="text-align:center;">6</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>
 </div>
 <div style="display:none">
 <h3>Page 3</h3>
-<table class="st-9209a8dc">
+<table class="st-4066ae2a">
     <style>
-        .st-9209a8dc {
+        .st-4066ae2a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -162,29 +162,29 @@ Page 4
             line-height: 1.2em;
         }
 
-        .st-9209a8dc tr td {
+        .st-4066ae2a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9209a8dc br {
+        .st-4066ae2a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9209a8dc sub {
+        .st-4066ae2a sub {
             line-height: 0;
         }
 
-        .st-9209a8dc sup {
+        .st-4066ae2a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -192,7 +192,7 @@ Page 4
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -203,19 +203,19 @@ Page 4
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">3</td>
         <td style="text-align:center;">4</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>
 </div>
 <div style="display:none">
 <h3>Page 4</h3>
-<table class="st-a16d1ac2">
+<table class="st-76ae7861">
     <style>
-        .st-a16d1ac2 {
+        .st-76ae7861 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -224,29 +224,29 @@ Page 4
             line-height: 1.2em;
         }
 
-        .st-a16d1ac2 tr td {
+        .st-76ae7861 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-a16d1ac2 br {
+        .st-76ae7861 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-a16d1ac2 sub {
+        .st-76ae7861 sub {
             line-height: 0;
         }
 
-        .st-a16d1ac2 sup {
+        .st-76ae7861 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -254,7 +254,7 @@ Page 4
     </tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -265,12 +265,12 @@ Page 4
         <td style="font-weight:bold;text-align:left;">group3</td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">d</td>
         <td style="text-align:center;">7</td>
         <td style="text-align:center;">8</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>
 </div>
 </div>

--- a/test/references/replace/replace_predicate_function.txt
+++ b/test/references/replace/replace_predicate_function.txt
@@ -1,6 +1,6 @@
-<table class="st-9ffd5034">
+<table class="st-e46b9973">
     <style>
-        .st-9ffd5034 {
+        .st-e46b9973 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-9ffd5034 tr td {
+        .st-e46b9973 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9ffd5034 br {
+        .st-e46b9973 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9ffd5034 sub {
+        .st-e46b9973 sub {
             line-height: 0;
         }
 
-        .st-9ffd5034 sup {
+        .st-e46b9973 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">missing</td>
         <td style="text-align:center;"></td>
@@ -37,5 +37,5 @@
         <td style="text-align:center;">11</td>
         <td style="text-align:center;">12</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/replace/replace_predicate_value.txt
+++ b/test/references/replace/replace_predicate_value.txt
@@ -1,6 +1,6 @@
-<table class="st-e576301b">
+<table class="st-ac45e282">
     <style>
-        .st-e576301b {
+        .st-ac45e282 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-e576301b tr td {
+        .st-ac45e282 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-e576301b br {
+        .st-ac45e282 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-e576301b sub {
+        .st-ac45e282 sub {
             line-height: 0;
         }
 
-        .st-e576301b sup {
+        .st-ac45e282 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">missing</td>
         <td style="text-align:center;"></td>
@@ -37,5 +37,5 @@
         <td style="text-align:center;">an Int was here</td>
         <td style="text-align:center;">an Int was here</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/replace/replacemissing_custom.txt
+++ b/test/references/replace/replacemissing_custom.txt
@@ -1,6 +1,6 @@
-<table class="st-0bfeea06">
+<table class="st-04498283">
     <style>
-        .st-0bfeea06 {
+        .st-04498283 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-0bfeea06 tr td {
+        .st-04498283 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-0bfeea06 br {
+        .st-04498283 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-0bfeea06 sub {
+        .st-04498283 sub {
             line-height: 0;
         }
 
-        .st-0bfeea06 sup {
+        .st-04498283 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">???</td>
         <td style="text-align:center;"></td>
@@ -37,5 +37,5 @@
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/replace/replacemissing_default.txt
+++ b/test/references/replace/replacemissing_default.txt
@@ -1,6 +1,6 @@
-<table class="st-394a5f07">
+<table class="st-b9608afb">
     <style>
-        .st-394a5f07 {
+        .st-b9608afb {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-394a5f07 tr td {
+        .st-b9608afb tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-394a5f07 br {
+        .st-b9608afb br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-394a5f07 sub {
+        .st-b9608afb sub {
             line-height: 0;
         }
 
-        .st-394a5f07 sup {
+        .st-b9608afb sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">-</td>
         <td style="text-align:center;">-</td>
@@ -37,6 +37,6 @@
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="2" style="font-size: 0.8em;">- No value</td></tr>
 </table>

--- a/test/references/row_and_column_gaps/singlecell.txt
+++ b/test/references/row_and_column_gaps/singlecell.txt
@@ -1,6 +1,6 @@
-<table class="st-fd5d5fac">
+<table class="st-4b106b12">
     <style>
-        .st-fd5d5fac {
+        .st-4b106b12 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-fd5d5fac tr td {
+        .st-4b106b12 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-fd5d5fac br {
+        .st-4b106b12 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-fd5d5fac sub {
+        .st-4b106b12 sub {
             line-height: 0;
         }
 
-        .st-fd5d5fac sup {
+        .st-4b106b12 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="padding-bottom: 2.0pt;text-align:center;">1, 1</td>
         <td style="padding-right:2.0pt;padding-bottom: 2.0pt;text-align:center;">1, 2</td>
@@ -53,5 +53,5 @@
         <td style="padding-left:2.0pt;padding-right:4.0pt;text-align:center;">4, 3</td>
         <td style="padding-left:4.0pt;text-align:center;">4, 4</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/row_and_column_gaps/spanned_cells.txt
+++ b/test/references/row_and_column_gaps/spanned_cells.txt
@@ -1,6 +1,6 @@
-<table class="st-d7f76253">
+<table class="st-e89fb123">
     <style>
-        .st-d7f76253 {
+        .st-e89fb123 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-d7f76253 tr td {
+        .st-e89fb123 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-d7f76253 br {
+        .st-e89fb123 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-d7f76253 sub {
+        .st-e89fb123 sub {
             line-height: 0;
         }
 
-        .st-d7f76253 sup {
+        .st-e89fb123 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="padding-bottom: 2.0pt;text-align:center;"></td>
         <td colspan="3" style="padding-bottom: 2.0pt;text-align:center;">Spanned columns</td>
@@ -49,5 +49,5 @@
         <td style="padding-left:2.0pt;text-align:center;"></td>
         <td style="text-align:center;"></td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/styles/valign.txt
+++ b/test/references/styles/valign.txt
@@ -1,6 +1,6 @@
-<table class="st-01ef69bb">
+<table class="st-bbaa5420">
     <style>
-        .st-01ef69bb {
+        .st-bbaa5420 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,26 +9,26 @@
             line-height: 1.2em;
         }
 
-        .st-01ef69bb tr td {
+        .st-bbaa5420 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-01ef69bb br {
+        .st-bbaa5420 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-01ef69bb sub {
+        .st-bbaa5420 sub {
             line-height: 0;
         }
 
-        .st-01ef69bb sup {
+        .st-bbaa5420 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;">Row 1</td>
         <td rowspan="3" style="text-align:center;">top</td>
@@ -41,5 +41,5 @@
     <tr>
         <td style="text-align:center;">Row 3</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/missing_groups.txt
+++ b/test/references/summarytable/missing_groups.txt
@@ -1,6 +1,6 @@
-<table class="st-c751c4b8">
+<table class="st-fc293c18">
     <style>
-        .st-c751c4b8 {
+        .st-fc293c18 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-c751c4b8 tr td {
+        .st-fc293c18 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-c751c4b8 br {
+        .st-fc293c18 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-c751c4b8 sub {
+        .st-fc293c18 sub {
             line-height: 0;
         }
 
-        .st-c751c4b8 sup {
+        .st-fc293c18 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">B</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">B</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -46,7 +46,7 @@
         <td style="text-align:center;"></td>
         <td colspan="3" style="font-weight:bold;text-align:center;">value</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">&apos;a&apos;</td>
         <td style="font-weight:bold;text-align:left;">sum</td>
         <td style="text-align:center;"></td>
@@ -67,5 +67,5 @@
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">3</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/natural_sort_order.txt
+++ b/test/references/summarytable/natural_sort_order.txt
@@ -1,6 +1,6 @@
-<table class="st-a14a3200">
+<table class="st-9a71cf96">
     <style>
-        .st-a14a3200 {
+        .st-9a71cf96 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,33 +9,33 @@
             line-height: 1.2em;
         }
 
-        .st-a14a3200 tr td {
+        .st-9a71cf96 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-a14a3200 br {
+        .st-9a71cf96 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-a14a3200 sub {
+        .st-9a71cf96 sub {
             line-height: 0;
         }
 
-        .st-a14a3200 sup {
+        .st-9a71cf96 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="font-weight:bold;text-align:left;">id</td>
         <td style="font-weight:bold;text-align:left;">dose</td>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">value</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">1</td>
         <td style="text-align:left;">1 mg</td>
         <td style="font-weight:bold;text-align:left;">mean</td>
@@ -101,5 +101,5 @@
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">4</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/no_group_one_summary.txt
+++ b/test/references/summarytable/no_group_one_summary.txt
@@ -1,6 +1,6 @@
-<table class="st-afda37be">
+<table class="st-b2e3fad5">
     <style>
-        .st-afda37be {
+        .st-b2e3fad5 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,33 +9,33 @@
             line-height: 1.2em;
         }
 
-        .st-afda37be tr td {
+        .st-b2e3fad5 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-afda37be br {
+        .st-b2e3fad5 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-afda37be sub {
+        .st-b2e3fad5 sub {
             line-height: 0;
         }
 
-        .st-afda37be sup {
+        .st-b2e3fad5 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">4.5</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/no_group_two_summaries.txt
+++ b/test/references/summarytable/no_group_two_summaries.txt
@@ -1,6 +1,6 @@
-<table class="st-aaa80618">
+<table class="st-3f615a06">
     <style>
-        .st-aaa80618 {
+        .st-3f615a06 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-aaa80618 tr td {
+        .st-3f615a06 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-aaa80618 br {
+        .st-3f615a06 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-aaa80618 sub {
+        .st-3f615a06 sub {
             line-height: 0;
         }
 
-        .st-aaa80618 sup {
+        .st-3f615a06 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">4.5</td>
     </tr>
@@ -41,5 +41,5 @@
         <td style="font-weight:bold;text-align:left;">SD</td>
         <td style="text-align:center;">2.45</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/one_rowgroup_one_colgroup_one_summary.txt
+++ b/test/references/summarytable/one_rowgroup_one_colgroup_one_summary.txt
@@ -1,6 +1,6 @@
-<table class="st-0cb1e11a">
+<table class="st-e21e5cf9">
     <style>
-        .st-0cb1e11a {
+        .st-e21e5cf9 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-0cb1e11a tr td {
+        .st-e21e5cf9 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-0cb1e11a br {
+        .st-e21e5cf9 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-0cb1e11a sub {
+        .st-e21e5cf9 sub {
             line-height: 0;
         }
 
-        .st-0cb1e11a sup {
+        .st-e21e5cf9 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">Group 2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">Group 2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="text-align:center;"></td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">a</td>
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">2</td>
@@ -57,5 +57,5 @@
         <td style="text-align:center;">6</td>
         <td style="text-align:center;">7</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/one_rowgroup_one_colgroup_two_summaries.txt
+++ b/test/references/summarytable/one_rowgroup_one_colgroup_two_summaries.txt
@@ -1,6 +1,6 @@
-<table class="st-42830a85">
+<table class="st-bc7b14bd">
     <style>
-        .st-42830a85 {
+        .st-bc7b14bd {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-42830a85 tr td {
+        .st-bc7b14bd tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-42830a85 br {
+        .st-bc7b14bd br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-42830a85 sub {
+        .st-bc7b14bd sub {
             line-height: 0;
         }
 
-        .st-42830a85 sup {
+        .st-bc7b14bd sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">Group 2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">Group 2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -45,7 +45,7 @@
         <td style="text-align:center;"></td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">a</td>
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">2</td>
@@ -67,5 +67,5 @@
         <td style="text-align:center;">1.41</td>
         <td style="text-align:center;">1.41</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/one_rowgroup_one_summary.txt
+++ b/test/references/summarytable/one_rowgroup_one_summary.txt
@@ -1,6 +1,6 @@
-<table class="st-62c73649">
+<table class="st-8dbcf8ea">
     <style>
-        .st-62c73649 {
+        .st-8dbcf8ea {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,32 +9,32 @@
             line-height: 1.2em;
         }
 
-        .st-62c73649 tr td {
+        .st-8dbcf8ea tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-62c73649 br {
+        .st-8dbcf8ea br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-62c73649 sub {
+        .st-8dbcf8ea sub {
             line-height: 0;
         }
 
-        .st-62c73649 sup {
+        .st-8dbcf8ea sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="font-weight:bold;text-align:left;">Group 1</td>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="text-align:left;">a</td>
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">2.5</td>
@@ -44,5 +44,5 @@
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">6.5</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/one_rowgroup_two_summaries.txt
+++ b/test/references/summarytable/one_rowgroup_two_summaries.txt
@@ -1,6 +1,6 @@
-<table class="st-2427eba3">
+<table class="st-a6c43a6c">
     <style>
-        .st-2427eba3 {
+        .st-a6c43a6c {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,32 +9,32 @@
             line-height: 1.2em;
         }
 
-        .st-2427eba3 tr td {
+        .st-a6c43a6c tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-2427eba3 br {
+        .st-a6c43a6c br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-2427eba3 sub {
+        .st-a6c43a6c sub {
             line-height: 0;
         }
 
-        .st-2427eba3 sup {
+        .st-a6c43a6c sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="font-weight:bold;text-align:left;">Group 1</td>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">a</td>
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">2.5</td>
@@ -52,5 +52,5 @@
         <td style="font-weight:bold;text-align:left;">std</td>
         <td style="text-align:center;">1.29</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/sort_false.txt
+++ b/test/references/summarytable/sort_false.txt
@@ -1,6 +1,6 @@
-<table class="st-7ed89ffe">
+<table class="st-bd3440a2">
     <style>
-        .st-7ed89ffe {
+        .st-bd3440a2 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-7ed89ffe tr td {
+        .st-bd3440a2 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-7ed89ffe br {
+        .st-bd3440a2 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-7ed89ffe sub {
+        .st-bd3440a2 sub {
             line-height: 0;
         }
 
-        .st-7ed89ffe sup {
+        .st-bd3440a2 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="6" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="6" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">parameters</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">parameters</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -49,7 +49,7 @@
         <td style="text-align:center;"></td>
         <td colspan="3" style="font-weight:bold;text-align:center;">value</td>
     </tr>
-        <tr><td colspan="6" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="6" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="2" style="text-align:left;">1</td>
         <td style="text-align:left;">1</td>
         <td style="font-weight:bold;text-align:left;">mean</td>
@@ -79,5 +79,5 @@
         <td style="text-align:center;">8</td>
         <td style="text-align:center;">12</td>
     </tr>
-    <tr><td colspan="6" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="6" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries.txt
+++ b/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries.txt
@@ -1,6 +1,6 @@
-<table class="st-ae5beebb">
+<table class="st-51c60b5d">
     <style>
-        .st-ae5beebb {
+        .st-51c60b5d {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-ae5beebb tr td {
+        .st-51c60b5d tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-ae5beebb br {
+        .st-51c60b5d br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-ae5beebb sub {
+        .st-51c60b5d sub {
             line-height: 0;
         }
 
-        .st-ae5beebb sup {
+        .st-51c60b5d sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">Group 3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">Group 3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -48,7 +48,7 @@
         <td style="text-align:center;"></td>
         <td colspan="2" style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="4" style="text-align:left;">a</td>
         <td rowspan="2" style="text-align:left;">e</td>
         <td style="font-weight:bold;text-align:left;">mean</td>
@@ -94,5 +94,5 @@
         <td style="text-align:center;">NaN</td>
         <td style="text-align:center;">NaN</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries_no_header.txt
+++ b/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries_no_header.txt
@@ -1,6 +1,6 @@
-<table class="st-f1279772">
+<table class="st-4f660f87">
     <style>
-        .st-f1279772 {
+        .st-4f660f87 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-f1279772 tr td {
+        .st-4f660f87 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-f1279772 br {
+        .st-4f660f87 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-f1279772 sub {
+        .st-4f660f87 sub {
             line-height: 0;
         }
 
-        .st-f1279772 sup {
+        .st-4f660f87 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">Group 3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">Group 3</td>
     </tr>
     <tr>
         <td style="font-weight:bold;text-align:left;">Group 1</td>
@@ -42,7 +42,7 @@
         <td style="text-align:center;">c</td>
         <td style="text-align:center;">d</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td rowspan="4" style="text-align:left;">a</td>
         <td rowspan="2" style="text-align:left;">e</td>
         <td style="font-weight:bold;text-align:left;">mean</td>
@@ -88,5 +88,5 @@
         <td style="text-align:center;">NaN</td>
         <td style="text-align:center;">NaN</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/summarytable/two_same_summaries.txt
+++ b/test/references/summarytable/two_same_summaries.txt
@@ -1,6 +1,6 @@
-<table class="st-6cbc5fc8">
+<table class="st-79c74910">
     <style>
-        .st-6cbc5fc8 {
+        .st-79c74910 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-6cbc5fc8 tr td {
+        .st-79c74910 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-6cbc5fc8 br {
+        .st-79c74910 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-6cbc5fc8 sub {
+        .st-79c74910 sub {
             line-height: 0;
         }
 
-        .st-6cbc5fc8 sup {
+        .st-79c74910 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">value1</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">4.5</td>
     </tr>
@@ -41,5 +41,5 @@
         <td style="font-weight:bold;text-align:left;">mean</td>
         <td style="text-align:center;">4.5</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/all_missing_group.txt
+++ b/test/references/table_one/all_missing_group.txt
@@ -1,6 +1,6 @@
-<table class="st-6e8d0ac2">
+<table class="st-ec1ea708">
     <style>
-        .st-6e8d0ac2 {
+        .st-ec1ea708 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-6e8d0ac2 tr td {
+        .st-ec1ea708 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-6e8d0ac2 br {
+        .st-ec1ea708 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-6e8d0ac2 sub {
+        .st-ec1ea708 sub {
             line-height: 0;
         }
 
-        .st-6e8d0ac2 sup {
+        .st-ec1ea708 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -40,7 +40,7 @@
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">empty</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -64,6 +64,6 @@
         <td style="text-align:center;">3 (100%)</td>
         <td style="text-align:center;">0 (0%)</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr><td colspan="4" style="font-size: 0.8em;">NC - Not computable</td></tr>
 </table>

--- a/test/references/table_one/category_with_missing.txt
+++ b/test/references/table_one/category_with_missing.txt
@@ -1,6 +1,6 @@
-<table class="st-02bb673e">
+<table class="st-7841d3ce">
     <style>
-        .st-02bb673e {
+        .st-7841d3ce {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-02bb673e tr td {
+        .st-7841d3ce tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-02bb673e br {
+        .st-7841d3ce br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-02bb673e sub {
+        .st-7841d3ce sub {
             line-height: 0;
         }
 
-        .st-02bb673e sup {
+        .st-7841d3ce sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -40,7 +40,7 @@
         <td style="text-align:center;">1</td>
         <td style="text-align:center;">2</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">category</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -70,5 +70,5 @@
         <td style="text-align:center;">0 (0%)</td>
         <td style="text-align:center;">1 (25%)</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/group_totals_three_groups_one_total_level_three.txt
+++ b/test/references/table_one/group_totals_three_groups_one_total_level_three.txt
@@ -1,6 +1,6 @@
-<table class="st-9fe485be">
+<table class="st-d188d59f">
     <style>
-        .st-9fe485be {
+        .st-d188d59f {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-9fe485be tr td {
+        .st-d188d59f tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9fe485be br {
+        .st-d188d59f br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9fe485be sub {
+        .st-d188d59f sub {
             line-height: 0;
         }
 
-        .st-9fe485be sup {
+        .st-d188d59f sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="14" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="14" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="12" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="12" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -43,8 +43,8 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="6" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td colspan="6" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="6" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="6" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -57,10 +57,10 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -78,7 +78,7 @@
         <td style="text-align:center;">d<br>(n=1)</td>
         <td style="text-align:center;">Total<br>(n=2)</td>
     </tr>
-        <tr><td colspan="14" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="14" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -190,5 +190,5 @@
         <td style="text-align:center;">0 (0%)</td>
         <td style="text-align:center;">1 (50%)</td>
     </tr>
-    <tr><td colspan="14" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="14" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/group_totals_three_groups_one_total_level_two.txt
+++ b/test/references/table_one/group_totals_three_groups_one_total_level_two.txt
@@ -1,6 +1,6 @@
-<table class="st-13fd3776">
+<table class="st-42dd633b">
     <style>
-        .st-13fd3776 {
+        .st-42dd633b {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-13fd3776 tr td {
+        .st-42dd633b tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-13fd3776 br {
+        .st-42dd633b br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-13fd3776 sub {
+        .st-42dd633b sub {
             line-height: 0;
         }
 
-        .st-13fd3776 sup {
+        .st-42dd633b sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="12" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="12" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="10" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="10" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -43,8 +43,8 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="5" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td colspan="5" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="5" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="5" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -59,11 +59,11 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group3</td>
         <td style="text-align:center;"></td>
     </tr>
     <tr>
@@ -80,7 +80,7 @@
         <td style="text-align:center;">d<br>(n=1)</td>
         <td style="text-align:center;"></td>
     </tr>
-        <tr><td colspan="12" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="12" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -178,5 +178,5 @@
         <td style="text-align:center;">0 (0%)</td>
         <td style="text-align:center;">1 (25%)</td>
     </tr>
-    <tr><td colspan="12" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="12" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/group_totals_two_groups_one_total.txt
+++ b/test/references/table_one/group_totals_two_groups_one_total.txt
@@ -1,6 +1,6 @@
-<table class="st-015c5dde">
+<table class="st-6ecb8193">
     <style>
-        .st-015c5dde {
+        .st-6ecb8193 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-015c5dde tr td {
+        .st-6ecb8193 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-015c5dde br {
+        .st-6ecb8193 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-015c5dde sub {
+        .st-6ecb8193 sub {
             line-height: 0;
         }
 
-        .st-015c5dde sup {
+        .st-6ecb8193 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="8" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="8" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="6" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="6" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -43,8 +43,8 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -56,7 +56,7 @@
         <td style="text-align:center;">f</td>
         <td style="text-align:center;">Total</td>
     </tr>
-        <tr><td colspan="8" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="8" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -126,5 +126,5 @@
         <td style="text-align:center;">1 (50%)</td>
         <td style="text-align:center;">1 (25%)</td>
     </tr>
-    <tr><td colspan="8" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="8" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/missing_as_a_group_factor.txt
+++ b/test/references/table_one/missing_as_a_group_factor.txt
@@ -1,6 +1,6 @@
-<table class="st-4edf7071">
+<table class="st-d8d05b10">
     <style>
-        .st-4edf7071 {
+        .st-d8d05b10 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-4edf7071 tr td {
+        .st-d8d05b10 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-4edf7071 br {
+        .st-d8d05b10 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-4edf7071 sub {
+        .st-d8d05b10 sub {
             line-height: 0;
         }
 
-        .st-4edf7071 sup {
+        .st-d8d05b10 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="7" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="5" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="5" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -44,9 +44,9 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -57,7 +57,7 @@
         <td style="text-align:center;">Total</td>
         <td style="text-align:center;">missing</td>
     </tr>
-        <tr><td colspan="7" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="7" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -84,5 +84,5 @@
         <td style="text-align:center;">4.5 [4, 5]</td>
         <td style="text-align:center;">4 [2, 6]</td>
     </tr>
-    <tr><td colspan="7" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/natural_sort_order.txt
+++ b/test/references/table_one/natural_sort_order.txt
@@ -1,6 +1,6 @@
-<table class="st-f6e5b3d6">
+<table class="st-d63c682a">
     <style>
-        .st-f6e5b3d6 {
+        .st-d63c682a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-f6e5b3d6 tr td {
+        .st-d63c682a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-f6e5b3d6 br {
+        .st-d63c682a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-f6e5b3d6 sub {
+        .st-d63c682a sub {
             line-height: 0;
         }
 
-        .st-f6e5b3d6 sup {
+        .st-d63c682a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="6" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="6" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">dose</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">dose</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -42,7 +42,7 @@
         <td style="text-align:center;">10 mg</td>
         <td style="text-align:center;">50 mg</td>
     </tr>
-        <tr><td colspan="6" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="6" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -66,5 +66,5 @@
         <td style="text-align:center;">4 [4, 5]</td>
         <td style="text-align:center;">2 [2, 3]</td>
     </tr>
-    <tr><td colspan="6" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="6" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/nested_spans_bad_sort.txt
+++ b/test/references/table_one/nested_spans_bad_sort.txt
@@ -1,6 +1,6 @@
-<table class="st-afdfb013">
+<table class="st-7325533f">
     <style>
-        .st-afdfb013 {
+        .st-7325533f {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-afdfb013 tr td {
+        .st-7325533f tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-afdfb013 br {
+        .st-7325533f br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-afdfb013 sub {
+        .st-7325533f sub {
             line-height: 0;
         }
 
-        .st-afdfb013 sup {
+        .st-7325533f sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="6" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="6" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">y</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">y</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -44,9 +44,9 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">z</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">z</td>
-        <td style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">z</td>
+        <td style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">z</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">z</td>
+        <td style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">z</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -56,7 +56,7 @@
         <td style="text-align:center;">D</td>
         <td style="text-align:center;">D</td>
     </tr>
-        <tr><td colspan="6" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="6" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">x</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -80,5 +80,5 @@
         <td style="text-align:center;">4.5 [4, 5]</td>
         <td style="text-align:center;">6 [6, 6]</td>
     </tr>
-    <tr><td colspan="6" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="6" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/one_row.txt
+++ b/test/references/table_one/one_row.txt
@@ -1,6 +1,6 @@
-<table class="st-385bc157">
+<table class="st-20db2305">
     <style>
-        .st-385bc157 {
+        .st-20db2305 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-385bc157 tr td {
+        .st-20db2305 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-385bc157 br {
+        .st-20db2305 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-385bc157 sub {
+        .st-20db2305 sub {
             line-height: 0;
         }
 
-        .st-385bc157 sup {
+        .st-20db2305 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">Total</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
     </tr>
@@ -45,5 +45,5 @@
         <td style="padding-left:12.0pt;text-align:left;">Median [Min, Max]</td>
         <td style="text-align:center;">4.5 [1, 8]</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/one_row_one_group_pvalues_tests_confints.txt
+++ b/test/references/table_one/one_row_one_group_pvalues_tests_confints.txt
@@ -1,6 +1,6 @@
-<table class="st-cbd712ae">
+<table class="st-371039a9">
     <style>
-        .st-cbd712ae {
+        .st-371039a9 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-cbd712ae tr td {
+        .st-371039a9 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-cbd712ae br {
+        .st-371039a9 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-cbd712ae sub {
+        .st-371039a9 sub {
             line-height: 0;
         }
 
-        .st-cbd712ae sup {
+        .st-371039a9 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="7" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -46,7 +46,7 @@
         <td style="font-weight:bold;text-align:center;">Test</td>
         <td style="font-weight:bold;text-align:center;">CI</td>
     </tr>
-        <tr><td colspan="7" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="7" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -73,5 +73,5 @@
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
     </tr>
-    <tr><td colspan="7" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/one_row_renamed.txt
+++ b/test/references/table_one/one_row_renamed.txt
@@ -1,6 +1,6 @@
-<table class="st-da257d7a">
+<table class="st-c9d83b69">
     <style>
-        .st-da257d7a {
+        .st-c9d83b69 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-da257d7a tr td {
+        .st-c9d83b69 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-da257d7a br {
+        .st-c9d83b69 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-da257d7a sub {
+        .st-c9d83b69 sub {
             line-height: 0;
         }
 
-        .st-da257d7a sup {
+        .st-c9d83b69 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">Total</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">Value 1</td>
         <td style="text-align:center;"></td>
     </tr>
@@ -45,5 +45,5 @@
         <td style="padding-left:12.0pt;text-align:left;">Median [Min, Max]</td>
         <td style="text-align:center;">4.5 [1, 8]</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/one_row_two_groups_pvalues.txt
+++ b/test/references/table_one/one_row_two_groups_pvalues.txt
@@ -1,6 +1,6 @@
-<table class="st-9a544d64">
+<table class="st-fa4c3b07">
     <style>
-        .st-9a544d64 {
+        .st-fa4c3b07 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-9a544d64 tr td {
+        .st-fa4c3b07 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-9a544d64 br {
+        .st-fa4c3b07 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-9a544d64 sub {
+        .st-fa4c3b07 sub {
             line-height: 0;
         }
 
-        .st-9a544d64 sup {
+        .st-fa4c3b07 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="8" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="8" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
     </tr>
@@ -47,8 +47,8 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
     </tr>
@@ -62,7 +62,7 @@
         <td style="font-weight:bold;text-align:center;">P-Value</td>
         <td style="font-weight:bold;text-align:center;">Test</td>
     </tr>
-        <tr><td colspan="8" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="8" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -92,5 +92,5 @@
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
     </tr>
-    <tr><td colspan="8" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="8" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/single_arg.txt
+++ b/test/references/table_one/single_arg.txt
@@ -1,6 +1,6 @@
-<table class="st-df08b8df">
+<table class="st-ca6d4326">
     <style>
-        .st-df08b8df {
+        .st-ca6d4326 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-df08b8df tr td {
+        .st-ca6d4326 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-df08b8df br {
+        .st-ca6d4326 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-df08b8df sub {
+        .st-ca6d4326 sub {
             line-height: 0;
         }
 
-        .st-df08b8df sup {
+        .st-ca6d4326 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">Total</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
     </tr>
@@ -97,5 +97,5 @@
         <td style="padding-left:12.0pt;text-align:left;">f</td>
         <td style="text-align:center;">4 (50%)</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/single_arg_with_groupby.txt
+++ b/test/references/table_one/single_arg_with_groupby.txt
@@ -1,6 +1,6 @@
-<table class="st-72de841e">
+<table class="st-0e62401d">
     <style>
-        .st-72de841e {
+        .st-0e62401d {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-72de841e tr td {
+        .st-0e62401d tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-72de841e br {
+        .st-0e62401d br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-72de841e sub {
+        .st-0e62401d sub {
             line-height: 0;
         }
 
-        .st-72de841e sup {
+        .st-0e62401d sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -40,7 +40,7 @@
         <td style="text-align:center;">a</td>
         <td style="text-align:center;">b</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -118,5 +118,5 @@
         <td style="text-align:center;">2 (50%)</td>
         <td style="text-align:center;">2 (50%)</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/sort_false.txt
+++ b/test/references/table_one/sort_false.txt
@@ -1,6 +1,6 @@
-<table class="st-2bd61ee9">
+<table class="st-131baf94">
     <style>
-        .st-2bd61ee9 {
+        .st-131baf94 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-2bd61ee9 tr td {
+        .st-131baf94 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-2bd61ee9 br {
+        .st-131baf94 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-2bd61ee9 sub {
+        .st-131baf94 sub {
             line-height: 0;
         }
 
-        .st-2bd61ee9 sup {
+        .st-131baf94 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="3" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">parameters</td>
+        <td colspan="3" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">parameters</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -41,7 +41,7 @@
         <td style="text-align:center;">C<sup>max</sup></td>
         <td style="text-align:center;">One Line<br>Another Line</td>
     </tr>
-        <tr><td colspan="5" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="5" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -62,5 +62,5 @@
         <td style="text-align:center;">6.5 [5, 8]</td>
         <td style="text-align:center;">10.5 [9, 12]</td>
     </tr>
-    <tr><td colspan="5" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="5" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/two_rows.txt
+++ b/test/references/table_one/two_rows.txt
@@ -1,6 +1,6 @@
-<table class="st-5c6a7387">
+<table class="st-c7d545d7">
     <style>
-        .st-5c6a7387 {
+        .st-c7d545d7 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-5c6a7387 tr td {
+        .st-c7d545d7 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-5c6a7387 br {
+        .st-c7d545d7 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-5c6a7387 sub {
+        .st-c7d545d7 sub {
             line-height: 0;
         }
 
-        .st-5c6a7387 sup {
+        .st-c7d545d7 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">Total</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
     </tr>
@@ -61,5 +61,5 @@
         <td style="padding-left:12.0pt;text-align:left;">c</td>
         <td style="text-align:center;">2 (25%)</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/two_rows_one_group.txt
+++ b/test/references/table_one/two_rows_one_group.txt
@@ -1,6 +1,6 @@
-<table class="st-73643fbf">
+<table class="st-f5d5afa3">
     <style>
-        .st-73643fbf {
+        .st-f5d5afa3 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-73643fbf tr td {
+        .st-f5d5afa3 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-73643fbf br {
+        .st-f5d5afa3 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-73643fbf sub {
+        .st-f5d5afa3 sub {
             line-height: 0;
         }
 
-        .st-73643fbf sup {
+        .st-f5d5afa3 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -40,7 +40,7 @@
         <td style="text-align:center;">a</td>
         <td style="text-align:center;">b</td>
     </tr>
-        <tr><td colspan="4" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="4" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -82,5 +82,5 @@
         <td style="text-align:center;">1 (25%)</td>
         <td style="text-align:center;">1 (25%)</td>
     </tr>
-    <tr><td colspan="4" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="4" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/two_rows_one_group_show_overall_false.txt
+++ b/test/references/table_one/two_rows_one_group_show_overall_false.txt
@@ -1,6 +1,6 @@
-<table class="st-1f5609c8">
+<table class="st-12ab5a1a">
     <style>
-        .st-1f5609c8 {
+        .st-12ab5a1a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,36 +9,36 @@
             line-height: 1.2em;
         }
 
-        .st-1f5609c8 tr td {
+        .st-12ab5a1a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-1f5609c8 br {
+        .st-12ab5a1a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-1f5609c8 sub {
+        .st-12ab5a1a sub {
             line-height: 0;
         }
 
-        .st-1f5609c8 sup {
+        .st-12ab5a1a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;">a</td>
         <td style="text-align:center;">b</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -73,5 +73,5 @@
         <td style="text-align:center;">1 (25%)</td>
         <td style="text-align:center;">1 (25%)</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/two_rows_one_group_show_total_false.txt
+++ b/test/references/table_one/two_rows_one_group_show_total_false.txt
@@ -1,6 +1,6 @@
-<table class="st-1f5609c8">
+<table class="st-12ab5a1a">
     <style>
-        .st-1f5609c8 {
+        .st-12ab5a1a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,36 +9,36 @@
             line-height: 1.2em;
         }
 
-        .st-1f5609c8 tr td {
+        .st-12ab5a1a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-1f5609c8 br {
+        .st-12ab5a1a br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-1f5609c8 sub {
+        .st-12ab5a1a sub {
             line-height: 0;
         }
 
-        .st-1f5609c8 sup {
+        .st-12ab5a1a sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;">a</td>
         <td style="text-align:center;">b</td>
     </tr>
-        <tr><td colspan="3" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="3" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -73,5 +73,5 @@
         <td style="text-align:center;">1 (25%)</td>
         <td style="text-align:center;">1 (25%)</td>
     </tr>
-    <tr><td colspan="3" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="3" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/two_rows_two_groups.txt
+++ b/test/references/table_one/two_rows_two_groups.txt
@@ -1,6 +1,6 @@
-<table class="st-2f05fb3a">
+<table class="st-e3d6ddbb">
     <style>
-        .st-2f05fb3a {
+        .st-e3d6ddbb {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,30 +9,30 @@
             line-height: 1.2em;
         }
 
-        .st-2f05fb3a tr td {
+        .st-e3d6ddbb tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-2f05fb3a br {
+        .st-e3d6ddbb br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-2f05fb3a sub {
+        .st-e3d6ddbb sub {
             line-height: 0;
         }
 
-        .st-2f05fb3a sup {
+        .st-e3d6ddbb sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="6" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="6" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="4" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group1</td>
+        <td colspan="4" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group1</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -43,8 +43,8 @@
     <tr>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
-        <td colspan="2" style="font-weight:bold;border-bottom:1px solid black; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
+        <td colspan="2" style="font-weight:bold;border-bottom:1px solid currentColor; padding-bottom: 0.25em;text-align:center;">group2</td>
     </tr>
     <tr>
         <td style="text-align:center;"></td>
@@ -54,7 +54,7 @@
         <td style="text-align:center;">e</td>
         <td style="text-align:center;">f</td>
     </tr>
-        <tr><td colspan="6" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="6" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
         <td style="text-align:center;"></td>
@@ -110,5 +110,5 @@
         <td style="text-align:center;">0 (0%)</td>
         <td style="text-align:center;">1 (50%)</td>
     </tr>
-    <tr><td colspan="6" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="6" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>

--- a/test/references/table_one/vector_and_function_arguments.txt
+++ b/test/references/table_one/vector_and_function_arguments.txt
@@ -1,6 +1,6 @@
-<table class="st-551d89d6">
+<table class="st-97e6f609">
     <style>
-        .st-551d89d6 {
+        .st-97e6f609 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -9,31 +9,31 @@
             line-height: 1.2em;
         }
 
-        .st-551d89d6 tr td {
+        .st-97e6f609 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
         }
 
-        .st-551d89d6 br {
+        .st-97e6f609 br {
             line-height: 0em;
             margin: 0;
         }
 
-        .st-551d89d6 sub {
+        .st-97e6f609 sub {
             line-height: 0;
         }
 
-        .st-551d89d6 sup {
+        .st-97e6f609 sup {
             line-height: 0;
         }
     </style>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
     <tr>
         <td style="text-align:center;"></td>
         <td style="font-weight:bold;text-align:center;">Total</td>
     </tr>
-        <tr><td colspan="2" style="border-bottom:1px solid black;padding:0"></td></tr>    <tr>
+        <tr><td colspan="2" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
         <td style="font-weight:bold;text-align:left;">value1</td>
         <td style="text-align:center;"></td>
     </tr>
@@ -57,5 +57,5 @@
         <td style="padding-left:12.0pt;text-align:left;">SD</td>
         <td style="text-align:center;">2.45</td>
     </tr>
-    <tr><td colspan="2" style="border-bottom: 1.5px solid black; padding: 0"></td></tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
 </table>


### PR DESCRIPTION
- **Use `currentColor` for html to make lines visible in dark environments**
- **update refs**

Fixes #51 

## Before

<img width="579" alt="image" src="https://github.com/user-attachments/assets/c72e11c6-b4c0-4906-b763-ecb00c1bc007" />

## After

<img width="567" alt="image" src="https://github.com/user-attachments/assets/995b465e-33ce-4bd0-b1da-c0e41b9ac19c" />
