### PR TITLE
HTML compatibility fixes

### DIFF
--- a/src/renderers/html.jl
+++ b/src/renderers/html.jl
@@ -11,15 +11,16 @@ function Base.show(io::IO, ::MIME"text/html", ct::Table)
 
     _io = IOBuffer()
     
-    # The final table has a hash-based class name so that several different renderings (maybe even across
-    # SummaryTables.jl versions) don't conflict and influence each other.
+    # The final table has a hash-based id so that several different renderings (maybe even across
+    # SummaryTables.jl versions) don't conflict and influence each other. An id has higher CSS specificity
+    # than a class, so that makes interference from host CSS styles less likely.
     hash_placeholder = "<<HASH>>" # should not collide because it's not valid HTML and <> are not allowed otherwise
 
-    println(_io, "<table class=\"st-$(hash_placeholder)\">")
+    println(_io, "<table id=\"st-$(hash_placeholder)\">")
 
     print(_io, """
         <style>
-            .st-$(hash_placeholder) {
+            #st-$(hash_placeholder) {
                 border: none;
                 margin: 0 auto;
                 padding: 0.25rem;
@@ -27,23 +28,24 @@ function Base.show(io::IO, ::MIME"text/html", ct::Table)
                 border-spacing: 0.85em 0.2em;
                 line-height: 1.2em;
             }
-
-            .st-$(hash_placeholder) tr td {
+            #st-$(hash_placeholder) tr {
+                background-color: transparent;
+                border: none;
+            }
+            #st-$(hash_placeholder) tr td {
                 vertical-align: top;
                 padding: 0;
                 border: none;
+                background-color: transparent;
             }
-
-            .st-$(hash_placeholder) br {
+            #st-$(hash_placeholder) br {
                 line-height: 0em;
                 margin: 0;
             }
-
-            .st-$(hash_placeholder) sub {
+            #st-$(hash_placeholder) sub {
                 line-height: 0;
             }
-
-            .st-$(hash_placeholder) sup {
+            #st-$(hash_placeholder) sup {
                 line-height: 0;
             }
         </style>
@@ -115,6 +117,10 @@ function Base.show(io::IO, ::MIME"text/html", ct::Table)
             _showas(_io, MIME"text/html"(), footnote)
         end
         println(_io, "</td></tr>")
+    end
+
+    if ct.footer !== nothing
+        println(_io, "    </tfoot>")
     end
 
     print(_io, "</table>")

--- a/src/table_functions/listingtable.jl
+++ b/src/table_functions/listingtable.jl
@@ -183,21 +183,11 @@ end
 # nicer than just having the textual overview that you get printed out in the REPL
 function Base.show(io::IO, M::Union{MIME"text/html",MIME"juliavscode/html"}, p::PaginatedTable)
     println(io, "<div>")
-    println(io, """
-    <script>
-    function showPaginatedPage(el, index){
-        const container = el.parentElement.querySelector('div');
-        for (var i = 0; i<container.children.length; i++){
-            container.children[i].style.display = i == index ? 'block' : 'none';
-        }
-    }
-    </script>
-    """)
     for i in 1:length(p.pages)
         println(io, """
-        <button onclick="showPaginatedPage(this, $(i-1))">
-        Page $i
-        </button>
+        <button onclick="
+            [...this.parentElement.querySelector('div').children].forEach((e,j) => e.style.display = j==$(i-1) ? 'block' : 'none');
+        ">Page $i</button>
         """)
     end
     println(io, "<div>")


### PR DESCRIPTION
- **use id instead of class to get priority over documenter's and others' css**
- **use inline code for pagination buttons for compat with backends not allowing script tags**
