### PR TITLE
Add `Styled` for partial styling including text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.2.0 - 2025-02-24
 
-- Added `Styled` struct for partial styling of text within a cell, including bold, italic, underline and text color [#84](https://github.com/PumasAI/SummaryTables.jl/pull/84).
+- Added `Styled` struct for partial styling of text within a cell, including bold, italic, underline and text color. Note that you need to add `\usepackage{xcolor}` to use colored text in LaTeX. [#84](https://github.com/PumasAI/SummaryTables.jl/pull/84).
 
 ## 3.1.0 - 2025-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0 - 2025-02-24
+
+- Added `Styled` struct for partial styling of text within a cell, including bold, italic, underline and text color [#84](https://github.com/PumasAI/SummaryTables.jl/pull/84).
+
 ## 3.1.0 - 2025-02-20
 
 - Added `header` function to typst output such that the header section can repeat after page breaks [#79](https://github.com/PumasAI/SummaryTables.jl/pull/79).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SummaryTables"
 uuid = "6ce4ecf0-73a7-4ce3-9fb4-80ebfe887b60"
 authors = ["Julius <juliusk@pumas.ai>", "Mike <michael@pumas.ai>"]
-version = "3.1.0"
+version = "3.2.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/docs/src/reference/infrastructure/cell.md
+++ b/docs/src/reference/infrastructure/cell.md
@@ -131,7 +131,7 @@ To apply font styles only to a rendered value and not the whole cell, use the `S
 - `bold::Bool`
 - `italic::Bool`
 - `underline::Bool`
-- `color::String` a hex color string like #FF0000
+- `color::String` a hex color string like #FF0000. Note that you need to add `\usepackage{xcolor}` to use colored text in LaTeX.
 
 ```@example
 using SummaryTables

--- a/docs/src/reference/infrastructure/cell.md
+++ b/docs/src/reference/infrastructure/cell.md
@@ -123,6 +123,26 @@ cells = [
 Table(cells)
 ```
 
+#### `Styled`
+
+To apply font styles only to a rendered value and not the whole cell, use the `Styled` wrapper object. Together with `Concat` you can partially style a cell's content.
+
+`Styled` takes the following optional keyword arguments:
+- `bold::Bool`
+- `italic::Bool`
+- `underline::Bool`
+- `color::String` a hex color string like #FF0000
+
+```@example
+using SummaryTables
+
+text = Styled("Italic text and a bold red number: ", italic = true)
+number = Styled(sin(1.3), bold = true, color = "#FF0000")
+together = Concat(text, number)
+annotated = Annotated("Annotated", Styled("Styled footnote", color = "#00CC00"))
+Table(Cell.([together annotated]))
+```
+
 ## Optional argument 2: `cellstyle`
 
 You may pass the style settings of a `Cell` as a positional argument of type [`CellStyle`](@ref).

--- a/src/SummaryTables.jl
+++ b/src/SummaryTables.jl
@@ -34,6 +34,7 @@ export ReplaceMissing
 export Replace
 export Superscript
 export Subscript
+export Styled
 
 const DEFAULT_ROWGAP = 6.0
 

--- a/src/infrastructure/special_cell_values.jl
+++ b/src/infrastructure/special_cell_values.jl
@@ -151,3 +151,34 @@ struct RoundedFloat
     trailing_zeros::Bool
 end
 
+struct Color
+    rgb::NTuple{3,Float64}
+end
+
+function Color(hex::String)
+    @assert length(hex) == 7 && hex[1] == '#' "Hex string must be in the format \"#RRGGBB\""
+
+    r = parse(Int, hex[2:3], base=16) / 255
+    g = parse(Int, hex[4:5], base=16) / 255
+    b = parse(Int, hex[6:7], base=16) / 255
+
+    Color((r, g, b))
+end
+
+struct Styled
+    value
+    color::Union{Nothing,Color}
+    bold::Union{Nothing,Bool}
+    italic::Union{Nothing,Bool}
+    underline::Union{Nothing,Bool}
+end
+
+function Styled(
+    value;
+    color = nothing,
+    bold = nothing,
+    italic = nothing,
+    underline = nothing,
+)
+    Styled(value, Color(color), bold, italic, underline)
+end

--- a/src/infrastructure/special_cell_values.jl
+++ b/src/infrastructure/special_cell_values.jl
@@ -172,7 +172,7 @@ Create a `Styled` object wrapping `value` which renders `value` formatted accord
 - `bold::Union{Nothing,Bool}`
 - `italic::Union{Nothing,Bool}`
 - `underline::Union{Nothing,Bool}`
-- `color::Union{Nothing,String}` The text color as a hex RGB string like #FA03C7
+- `color::Union{Nothing,String}` The text color as a hex RGB string like #FA03C7.  Note that you need to add `\\usepackage{xcolor}` to use colored text in LaTeX.
 """
 struct Styled
     value

--- a/src/infrastructure/special_cell_values.jl
+++ b/src/infrastructure/special_cell_values.jl
@@ -165,6 +165,15 @@ function Color(hex::String)
     Color((r, g, b))
 end
 
+"""
+    Styled(value; color, bold, italic, underline)
+
+Create a `Styled` object wrapping `value` which renders `value` formatted according to these optional properties:
+- `bold::Union{Nothing,Bool}`
+- `italic::Union{Nothing,Bool}`
+- `underline::Union{Nothing,Bool}`
+- `color::Union{Nothing,String}` The text color as a hex RGB string like #FA03C7
+"""
 struct Styled
     value
     color::Union{Nothing,Color}
@@ -180,5 +189,5 @@ function Styled(
     italic = nothing,
     underline = nothing,
 )
-    Styled(value, Color(color), bold, italic, underline)
+    Styled(value, color === nothing ? nothing : Color(color), bold, italic, underline)
 end

--- a/src/infrastructure/tables.jl
+++ b/src/infrastructure/tables.jl
@@ -293,6 +293,7 @@ apply_rounder(x::AbstractFloat, r::Rounder) = RoundedFloat(x, r.round_digits, r.
 apply_rounder(x::Concat, r::Rounder) = Concat(map(arg -> apply_rounder(arg, r), x.args)...)
 apply_rounder(x::Multiline, r::Rounder) = Multiline(map(arg -> apply_rounder(arg, r), x.values)...)
 apply_rounder(x::Annotated, r::Rounder) = Annotated(apply_rounder(x.value, r), x.annotation, x.label)
+apply_rounder(x::Styled, r::Rounder) = Styled(apply_rounder(x.value, r), x.color, x.bold, x.italic, x.underline)
 
 function postprocess_cell(cell::Cell, r::Rounder)
     Cell(apply_rounder(cell.value, r), cell.style)

--- a/src/renderers/docx.jl
+++ b/src/renderers/docx.jl
@@ -297,6 +297,15 @@ function to_runs(r::ResolvedAnnotation, props)
     end
     return runs
 end
+
+_rgb_to_hex(rgb) = join(string.(round.(Int, rgb .* 255); base = 16, pad = 2))
+
+function to_runs(s::Styled, props::WriteDocx.RunProperties)
+    # TODO: add underline once WriteDocx fixes support for it
+    props = merge_props(props, WriteDocx.RunProperties(; s.bold, s.italic, color = s.color === nothing ? nothing : WriteDocx.HexColor(_rgb_to_hex(s.color.rgb))))
+    return to_runs(s.value, props)
+end
+
 docx_sprint(x) = sprint(x) do io, x
     _showas(io, MIME"text"(), x)
 end

--- a/src/renderers/html.jl
+++ b/src/renderers/html.jl
@@ -160,6 +160,25 @@ function _showas(io::IO, ::MIME"text/html", s::Subscript)
     print(io, "</sub>")
 end
 
+function _showas(io::IO, M::MIME"text/html", s::Styled)
+    print(io, "<span style=\"")
+    if s.bold !== nothing
+        print(io, "font-weight:$(s.bold ? "bold" : "normal");")
+    end
+    if s.italic !== nothing
+        print(io, "font-style:$(s.italic ? "italic" : "normal");")
+    end
+    if s.underline === true
+        print(io, "text-decoration:underline;")
+    end
+    if s.color !== nothing
+        print(io, "color:rgb($(join(s.color.rgb .* 255, ",")));")
+    end
+    print(io, "\">")
+    _showas(io, M, s.value)
+    print(io, "</span>")
+end
+
 function print_html_cell(io, cell::SpannedCell, rowgaps, colgaps)
     print(io, "<td")
     nrows, ncols = map(length, cell.span)

--- a/src/renderers/html.jl
+++ b/src/renderers/html.jl
@@ -172,7 +172,7 @@ function _showas(io::IO, M::MIME"text/html", s::Styled)
         print(io, "text-decoration:underline;")
     end
     if s.color !== nothing
-        print(io, "color:rgb($(join(s.color.rgb .* 255, ",")));")
+        print(io, "color:rgb($(join(round.(Int, s.color.rgb .* 255), ",")));")
     end
     print(io, "\">")
     _showas(io, M, s.value)

--- a/src/renderers/latex.jl
+++ b/src/renderers/latex.jl
@@ -215,6 +215,20 @@ function _showas(io::IO, ::MIME"text/latex", r::ResolvedAnnotation)
     end
 end
 
+function _showas(io::IO, ::MIME"text/latex", s::Styled)
+    s.bold === true && print(io, "\\textbf{")
+    s.italic === true && print(io, "\\textit{")
+    s.underline === true && print(io, "\\underline{")
+    if s.color !== nothing
+        print(io, "\\textcolor[RGB]{$(join(round.(Int, s.color.rgb .* 255), ","))}{")
+    end
+    _showas(io, MIME"text/latex"(), s.value)
+    s.color !== nothing && print(io, "}")
+    s.underline === true && print(io, "}")
+    s.italic === true && print(io, "}")
+    s.bold === true && print(io, "}")
+end
+
 function _str_latex_escaped(io::IO, s::AbstractString)
     escapable_special_chars = raw"&%$#_{}"
     a = Iterators.Stateful(s)

--- a/src/renderers/typst.jl
+++ b/src/renderers/typst.jl
@@ -170,6 +170,20 @@ function _showas(io::IO, ::MIME"text/typst", s::Subscript)
     print(io, "]")
 end
 
+function _showas(io::IO, M::MIME"text/typst", s::Styled)
+    s.bold === true && print(io, "*")
+    s.italic === true && print(io, "_")
+    s.underline === true && print(io, "#underline[")
+    if s.color !== nothing
+        print(io, "#text(fill: rgb($(join(round.(Int, s.color.rgb .* 255), ","))))[")
+    end
+    _showas(io, M, s.value)
+    s.color !== nothing && print(io, "]")
+    s.underline === true && print(io, "]")
+    s.italic === true && print(io, "_")
+    s.bold === true && print(io, "*")
+end
+
 function _str_typst_escaped(io::IO, s::AbstractString)
     escapable_special_chars = raw"\$#*_<@`"
     a = Iterators.Stateful(s)

--- a/test/references/annotations/annotated_float.latex.txt
+++ b/test/references/annotations/annotated_float.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/annotations/automatic_annotations.latex.txt
+++ b/test/references/annotations/automatic_annotations.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/annotations/manual_annotations.latex.txt
+++ b/test/references/annotations/manual_annotations.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/character_escaping/problematic_characters.latex.txt
+++ b/test/references/character_escaping/problematic_characters.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/auto_false_1.latex.txt
+++ b/test/references/global_rounding/auto_false_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/auto_false_3.latex.txt
+++ b/test/references/global_rounding/auto_false_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/auto_true_1.latex.txt
+++ b/test/references/global_rounding/auto_true_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/auto_true_3.latex.txt
+++ b/test/references/global_rounding/auto_true_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/default.latex.txt
+++ b/test/references/global_rounding/default.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/digits_false_1.latex.txt
+++ b/test/references/global_rounding/digits_false_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/digits_false_3.latex.txt
+++ b/test/references/global_rounding/digits_false_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/digits_true_1.latex.txt
+++ b/test/references/global_rounding/digits_true_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/digits_true_3.latex.txt
+++ b/test/references/global_rounding/digits_true_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/no_rounding.latex.txt
+++ b/test/references/global_rounding/no_rounding.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/sigdigits_false_1.latex.txt
+++ b/test/references/global_rounding/sigdigits_false_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/sigdigits_false_3.latex.txt
+++ b/test/references/global_rounding/sigdigits_false_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/sigdigits_true_1.latex.txt
+++ b/test/references/global_rounding/sigdigits_true_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/global_rounding/sigdigits_true_3.latex.txt
+++ b/test/references/global_rounding/sigdigits_true_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/cols_only.latex.txt
+++ b/test/references/listingtable/cols_only.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/missing_groups.latex.txt
+++ b/test/references/listingtable/missing_groups.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/natural_sort_order.latex.txt
+++ b/test/references/listingtable/natural_sort_order.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/no_variable_header.latex.txt
+++ b/test/references/listingtable/no_variable_header.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/one_row_two_cols.latex.txt
+++ b/test/references/listingtable/one_row_two_cols.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_cols=1_1.latex.txt
+++ b/test/references/listingtable/pagination_cols=1_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_cols=1_2.latex.txt
+++ b/test/references/listingtable/pagination_cols=1_2.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_cols=1_3.latex.txt
+++ b/test/references/listingtable/pagination_cols=1_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_cols=1_4.latex.txt
+++ b/test/references/listingtable/pagination_cols=1_4.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_cols=2_1.latex.txt
+++ b/test/references/listingtable/pagination_cols=2_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_cols=2_2.latex.txt
+++ b/test/references/listingtable/pagination_cols=2_2.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=1_1.latex.txt
+++ b/test/references/listingtable/pagination_rows=1_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=1_2.latex.txt
+++ b/test/references/listingtable/pagination_rows=1_2.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=1_3.latex.txt
+++ b/test/references/listingtable/pagination_rows=1_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=1_4.latex.txt
+++ b/test/references/listingtable/pagination_rows=1_4.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=1_cols=2_1.latex.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=1_cols=2_2.latex.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_2.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=1_cols=2_3.latex.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=1_cols=2_4.latex.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_4.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_1.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_2.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_2.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_summarized_1.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_1.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_2.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_2.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_1.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_1.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_2.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_2.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_3.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_3.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_4.latex.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_4.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/renaming.latex.txt
+++ b/test/references/listingtable/renaming.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/rows_only.latex.txt
+++ b/test/references/listingtable/rows_only.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/sort_false.latex.txt
+++ b/test/references/listingtable/sort_false.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/summarize_end_cols_two_funcs.latex.txt
+++ b/test/references/listingtable/summarize_end_cols_two_funcs.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/summarize_end_rows.latex.txt
+++ b/test/references/listingtable/summarize_end_rows.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/summarize_end_rows_two_funcs.latex.txt
+++ b/test/references/listingtable/summarize_end_rows_two_funcs.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/summarize_first_group_cols.latex.txt
+++ b/test/references/listingtable/summarize_first_group_cols.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/summarize_first_group_rows.latex.txt
+++ b/test/references/listingtable/summarize_first_group_rows.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/summarize_last_group_cols.latex.txt
+++ b/test/references/listingtable/summarize_last_group_cols.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/summarize_last_group_rows.latex.txt
+++ b/test/references/listingtable/summarize_last_group_rows.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/two_rows_one_col.latex.txt
+++ b/test/references/listingtable/two_rows_one_col.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/listingtable/two_same_summarizers.latex.txt
+++ b/test/references/listingtable/two_same_summarizers.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_false.latex.txt
+++ b/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_false.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_true.latex.txt
+++ b/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_true.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/manual_footnotes/footnotes_linebreaks_false.latex.txt
+++ b/test/references/manual_footnotes/footnotes_linebreaks_false.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/manual_footnotes/footnotes_linebreaks_true.latex.txt
+++ b/test/references/manual_footnotes/footnotes_linebreaks_true.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/merged_cells/custom_datatypes.latex.txt
+++ b/test/references/merged_cells/custom_datatypes.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/replace/replace_predicate_function.latex.txt
+++ b/test/references/replace/replace_predicate_function.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/replace/replace_predicate_value.latex.txt
+++ b/test/references/replace/replace_predicate_value.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/replace/replacemissing_custom.latex.txt
+++ b/test/references/replace/replacemissing_custom.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/replace/replacemissing_default.latex.txt
+++ b/test/references/replace/replacemissing_default.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/row_and_column_gaps/singlecell.latex.txt
+++ b/test/references/row_and_column_gaps/singlecell.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/row_and_column_gaps/spanned_cells.latex.txt
+++ b/test/references/row_and_column_gaps/spanned_cells.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/simple_table/no_args.latex.txt
+++ b/test/references/simple_table/no_args.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/simple_table/three_cols.latex.txt
+++ b/test/references/simple_table/three_cols.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/simple_table/three_cols_halign_left.latex.txt
+++ b/test/references/simple_table/three_cols_halign_left.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/simple_table/three_cols_halign_left_center_right.latex.txt
+++ b/test/references/simple_table/three_cols_halign_left_center_right.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/simple_table/three_cols_subheaders.latex.txt
+++ b/test/references/simple_table/three_cols_subheaders.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/simple_table/three_cols_subheaders_and_haligns.latex.txt
+++ b/test/references/simple_table/three_cols_subheaders_and_haligns.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/simple_table/three_cols_with_names.latex.txt
+++ b/test/references/simple_table/three_cols_with_names.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/styled/example.docx.txt
+++ b/test/references/styled/example.docx.txt
@@ -1,0 +1,311 @@
+############################## [Content_Types].xml ##############################
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types
+    xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="png" ContentType="image/png" />
+    <Default Extension="svg" ContentType="image/svg+xml" />
+    <Default Extension="xml" ContentType="application/xml" />
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+    <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml" />
+    <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml" />
+</Types>
+############################## _rels/.rels ##############################
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships
+    xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>
+############################## word/_rels/document.xml.rels ##############################
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>
+############################## word/styles.xml ##############################
+<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:docDefaults>
+    <w:rPrDefault/>
+    <w:pPrDefault/>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:styleId="Normal">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+      </w:rPr>
+    </w:pPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="NormalChar"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="character" w:styleId="NormalChar">
+    <w:rPr>
+      <w:sz w:val="20"/>
+    </w:rPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="Normal"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading1">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="40"/>
+      </w:rPr>
+      <w:spacing w:before="240" w:after="200"/>
+    </w:pPr>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading1Char">
+    <w:rPr/>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading2">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="32"/>
+      </w:rPr>
+      <w:spacing w:before="200" w:after="160"/>
+    </w:pPr>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading2Char">
+    <w:rPr/>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading3">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="28"/>
+      </w:rPr>
+      <w:spacing w:before="160" w:after="120"/>
+    </w:pPr>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading3Char">
+    <w:rPr/>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading4">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="24"/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading4Char">
+    <w:rPr/>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading5">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="22"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading5Char">
+    <w:rPr/>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading6">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading6Char">
+    <w:rPr/>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:latentStyles/>
+</w:styles>
+############################## word/document.xml ##############################
+<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:tbl>
+      <w:tblPr>
+        <w:tblCellMar>
+          <w:top w:w="0"/>
+          <w:bottom w:w="0"/>
+          <w:start w:w="30"/>
+          <w:end w:w="30"/>
+        </w:tblCellMar>
+        <w:tblCellSpacing w:w="20"/>
+      </w:tblPr>
+      <w:tr>
+        <w:trPr>
+          <w:tblHeader/>
+        </w:trPr>
+        <w:tc>
+          <w:tcPr>
+            <w:tcBorders>
+              <w:bottom w:val="single" w:color="auto" w:sz="8"/>
+              <w:end w:val="none" w:color="auto" w:sz="8"/>
+              <w:start w:val="none" w:color="auto" w:sz="8"/>
+            </w:tcBorders>
+            <w:gridSpan w:val="2"/>
+            <w:hideMark/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr/>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr/>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar/>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="center"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:color w:val="ff0000"/>
+              </w:rPr>
+              <w:t>Red</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t xml:space="preserve"> and </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:color w:val="0000ff"/>
+              </w:rPr>
+              <w:t>Blue</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar/>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="center"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:color w:val="00cc00"/>
+                <w:b/>
+                <w:i/>
+              </w:rPr>
+              <w:t>Green, bold, italic, underlined</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr/>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar/>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="center"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:color w:val="ff0000"/>
+              </w:rPr>
+              <w:t xml:space="preserve">Nested red </w:t>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:color w:val="0000ff"/>
+              </w:rPr>
+              <w:t>and blue</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar/>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="center"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:color w:val="abcdef"/>
+              </w:rPr>
+              <w:t>0.985</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr/>
+        <w:tc>
+          <w:tcPr>
+            <w:tcBorders>
+              <w:bottom w:val="single" w:color="auto" w:sz="8"/>
+              <w:end w:val="none" w:color="auto" w:sz="8"/>
+              <w:start w:val="none" w:color="auto" w:sz="8"/>
+            </w:tcBorders>
+            <w:gridSpan w:val="2"/>
+            <w:hideMark/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr/>
+          </w:p>
+        </w:tc>
+      </w:tr>
+    </w:tbl>
+    <w:sectPr/>
+  </w:body>
+</w:document>

--- a/test/references/styled/example.latex.txt
+++ b/test/references/styled/example.latex.txt
@@ -1,0 +1,18 @@
+\documentclass{article}
+\usepackage{threeparttable}
+\usepackage{multirow}
+\usepackage{booktabs}
+\begin{document}
+\begin{table}[!ht]
+\setlength\tabcolsep{0pt}
+\centering
+\begin{threeparttable}
+\begin{tabular}{@{\extracolsep{2ex}}*{2}{cc}}
+\toprule
+\textcolor[RGB]{255,0,0}{Red} and \textcolor[RGB]{0,0,255}{Blue} & \textbf{\textit{\underline{\textcolor[RGB]{0,204,0}{Green, bold, italic, underlined}}}} \\
+\textcolor[RGB]{0,0,255}{\textcolor[RGB]{255,0,0}{Nested red }and blue} & \textcolor[RGB]{171,205,239}{0.985} \\
+\bottomrule
+\end{tabular}
+\end{threeparttable}
+\end{table}
+\end{document}

--- a/test/references/styled/example.latex.txt
+++ b/test/references/styled/example.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/styled/example.txt
+++ b/test/references/styled/example.txt
@@ -1,0 +1,42 @@
+<table id="st-bd398dd5">
+    <style>
+        #st-bd398dd5 {
+            border: none;
+            margin: 0 auto;
+            padding: 0.25rem;
+            border-collapse: separate;
+            border-spacing: 0.85em 0.2em;
+            line-height: 1.2em;
+        }
+        #st-bd398dd5 tr {
+            background-color: transparent;
+            border: none;
+        }
+        #st-bd398dd5 tr td {
+            vertical-align: top;
+            padding: 0;
+            border: none;
+            background-color: transparent;
+        }
+        #st-bd398dd5 br {
+            line-height: 0em;
+            margin: 0;
+        }
+        #st-bd398dd5 sub {
+            line-height: 0;
+        }
+        #st-bd398dd5 sup {
+            line-height: 0;
+        }
+    </style>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
+    <tr>
+        <td style="text-align:center;"><span style="color:rgb(255,0,0);">Red</span> and <span style="color:rgb(0,0,255);">Blue</span></td>
+        <td style="text-align:center;"><span style="font-weight:bold;font-style:italic;text-decoration:underline;color:rgb(0,204,0);">Green, bold, italic, underlined</span></td>
+    </tr>
+    <tr>
+        <td style="text-align:center;"><span style="color:rgb(0,0,255);"><span style="color:rgb(255,0,0);">Nested red </span>and blue</span></td>
+        <td style="text-align:center;"><span style="color:rgb(171,205,239);">0.985</span></td>
+    </tr>
+    <tr><td colspan="2" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
+</table>

--- a/test/references/styled/example.typ.txt
+++ b/test/references/styled/example.typ.txt
@@ -1,0 +1,14 @@
+
+#table(
+    rows: 2,
+    columns: 2,
+    column-gutter: 0.25em,
+    align: (center, center),
+    stroke: none,
+    table.hline(y: 0, stroke: 1pt),
+    [#text(fill: rgb(255,0,0))[Red] and #text(fill: rgb(0,0,255))[Blue]],
+    [*_#underline[#text(fill: rgb(0,204,0))[Green, bold, italic, underlined]]_*],
+    [#text(fill: rgb(0,0,255))[#text(fill: rgb(255,0,0))[Nested red ]and blue]],
+    [#text(fill: rgb(171,205,239))[0.985]],
+    table.hline(y: 2, stroke: 1pt),
+)

--- a/test/references/styles/valign.latex.txt
+++ b/test/references/styles/valign.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/missing_groups.latex.txt
+++ b/test/references/summarytable/missing_groups.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/natural_sort_order.latex.txt
+++ b/test/references/summarytable/natural_sort_order.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/no_group_one_summary.latex.txt
+++ b/test/references/summarytable/no_group_one_summary.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/no_group_two_summaries.latex.txt
+++ b/test/references/summarytable/no_group_two_summaries.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/one_rowgroup_one_colgroup_one_summary.latex.txt
+++ b/test/references/summarytable/one_rowgroup_one_colgroup_one_summary.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/one_rowgroup_one_colgroup_two_summaries.latex.txt
+++ b/test/references/summarytable/one_rowgroup_one_colgroup_two_summaries.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/one_rowgroup_one_summary.latex.txt
+++ b/test/references/summarytable/one_rowgroup_one_summary.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/one_rowgroup_two_summaries.latex.txt
+++ b/test/references/summarytable/one_rowgroup_two_summaries.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/sort_false.latex.txt
+++ b/test/references/summarytable/sort_false.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries.latex.txt
+++ b/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries_no_header.latex.txt
+++ b/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries_no_header.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/summarytable/two_same_summaries.latex.txt
+++ b/test/references/summarytable/two_same_summaries.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/all_missing_group.latex.txt
+++ b/test/references/table_one/all_missing_group.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/category_with_missing.latex.txt
+++ b/test/references/table_one/category_with_missing.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/group_totals_three_groups_one_total_level_three.latex.txt
+++ b/test/references/table_one/group_totals_three_groups_one_total_level_three.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/group_totals_three_groups_one_total_level_two.latex.txt
+++ b/test/references/table_one/group_totals_three_groups_one_total_level_two.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/group_totals_two_groups_one_total.latex.txt
+++ b/test/references/table_one/group_totals_two_groups_one_total.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/missing_as_a_group_factor.latex.txt
+++ b/test/references/table_one/missing_as_a_group_factor.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/natural_sort_order.latex.txt
+++ b/test/references/table_one/natural_sort_order.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/nested_spans_bad_sort.latex.txt
+++ b/test/references/table_one/nested_spans_bad_sort.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/one_row.latex.txt
+++ b/test/references/table_one/one_row.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/one_row_one_group_pvalues_tests_confints.latex.txt
+++ b/test/references/table_one/one_row_one_group_pvalues_tests_confints.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/one_row_renamed.latex.txt
+++ b/test/references/table_one/one_row_renamed.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/one_row_two_groups_pvalues.latex.txt
+++ b/test/references/table_one/one_row_two_groups_pvalues.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/single_arg.latex.txt
+++ b/test/references/table_one/single_arg.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/single_arg_with_groupby.latex.txt
+++ b/test/references/table_one/single_arg_with_groupby.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/sort_false.latex.txt
+++ b/test/references/table_one/sort_false.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/two_rows.latex.txt
+++ b/test/references/table_one/two_rows.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/two_rows_one_group.latex.txt
+++ b/test/references/table_one/two_rows_one_group.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/two_rows_one_group_show_overall_false.latex.txt
+++ b/test/references/table_one/two_rows_one_group_show_overall_false.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/two_rows_one_group_show_total_false.latex.txt
+++ b/test/references/table_one/two_rows_one_group_show_total_false.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/two_rows_two_groups.latex.txt
+++ b/test/references/table_one/two_rows_two_groups.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/references/table_one/vector_and_function_arguments.latex.txt
+++ b/test/references/table_one/vector_and_function_arguments.latex.txt
@@ -2,6 +2,7 @@
 \usepackage{threeparttable}
 \usepackage{multirow}
 \usepackage{booktabs}
+\usepackage{xcolor}
 \begin{document}
 \begin{table}[!ht]
 \setlength\tabcolsep{0pt}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ function Base.show(io::IO, m::AsMIME{M}) where M <: MIME"text/latex"
         \usepackage{threeparttable}
         \usepackage{multirow}
         \usepackage{booktabs}
+        \usepackage{xcolor}
         \begin{document}
         """
     )
@@ -697,6 +698,18 @@ end
             reftest(t, "references/row_and_column_gaps/singlecell")
             t = Table([SpannedCell(2:4, 1, "Spanned rows"), SpannedCell(1, 2:4, "Spanned columns")], rowgaps = [1 => 4.0], colgaps = [2 => 4.0])
             reftest(t, "references/row_and_column_gaps/spanned_cells")
+        end
+
+        @testset "Styled" begin
+            conc = Concat(Styled("Red", color = "#FF0000"), " and ", Styled("Blue", color = "#0000FF")) 
+            all = Styled("Green, bold, italic, underlined", color = "#00CC00", bold = true, italic = true, underline = true)
+            nested = Styled(SummaryTables.Concat(Styled("Nested red ", color = "#FF0000"), "and blue"), color = "#0000FF")
+            number = Styled(sin(1.4), color = "#ABCDEF")
+            t = Table(Cell.([
+                conc all;
+                nested number;
+            ]))
+            reftest(t, "references/styled/example")
         end
     end
 end


### PR DESCRIPTION
Before, styles could only be applied per cell. With `Styled`, partial values can be wrapped with different styles.

Example:

```julia
using SummaryTables

text = Styled("Italic text and a bold red number: ", italic = true)
number = Styled(sin(1.3), bold = true, color = "#FF0000")
together = Concat(text, number)
annotated = Annotated("Annotated", Styled("Styled footnote", color = "#00CC00"))
Table(Cell.([together annotated]))
```

<img width="333" alt="image" src="https://github.com/user-attachments/assets/692fac8b-c30b-4284-a1c3-e2a58722e66c" />
