### PR TITLE
Handle columns with only missings in `overview_table`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed `overview_table` in the presence of all-missing columns [#91](https://github.com/PumasAI/SummaryTables.jl/pull/91).
+
 ## 3.3.0 - 2025-03-12
 
 - Added the `overview_table` function which creates a quick summary of all columns from a tabular data source, styled after the `dfSummary` function from R's `summarytools` package [#85](https://github.com/PumasAI/SummaryTables.jl/pull/85).

--- a/src/table_functions/overview_table.jl
+++ b/src/table_functions/overview_table.jl
@@ -65,7 +65,7 @@ function _overview_table(df::DataFrames.DataFrame; max_categories = 10, label_me
     Table([headers'; body]; header = 1, rowgaps = (1:length(columns)) .=> DEFAULT_ROWGAP, footnotes)
 end
 
-has_categorical_eltype(::AbstractVector{<:Union{Missing,Number}}) = false
+has_categorical_eltype(v::AbstractVector{<:Union{Missing,Number}}) = all(ismissing, v)
 has_categorical_eltype(::AbstractVector) = true
 
 function _stats_values_freqs_graph_continuous(column::AbstractVector)
@@ -172,6 +172,7 @@ function Base.show(io::IO, ::MIME"image/svg+xml", r::RectPlot)
 end
 
 function pretty_column_eltype(::AbstractVector{T}) where T
+    T === Missing && return "Missing"
     nonmissing = nonmissingtype(T)
     suffix = nonmissing == T ? "" : "?"
     # we don't want long names like [CategoricalArrays.CategoricalValue{String, UInt8}] here,

--- a/test/references/overview_table/only_missings.docx.txt
+++ b/test/references/overview_table/only_missings.docx.txt
@@ -1,0 +1,797 @@
+############################## [Content_Types].xml ##############################
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types
+    xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="png" ContentType="image/png" />
+    <Default Extension="svg" ContentType="image/svg+xml" />
+    <Default Extension="xml" ContentType="application/xml" />
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+    <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml" />
+    <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml" />
+</Types>
+############################## _rels/.rels ##############################
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships
+    xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>
+############################## word/_rels/document.xml.rels ##############################
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image_2.svg"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image_3.svg"/>
+</Relationships>
+############################## word/styles.xml ##############################
+<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:docDefaults>
+    <w:rPrDefault/>
+    <w:pPrDefault/>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:styleId="Normal">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+      </w:rPr>
+    </w:pPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="NormalChar"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="character" w:styleId="NormalChar">
+    <w:rPr>
+      <w:sz w:val="20"/>
+    </w:rPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="Normal"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading1">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="40"/>
+      </w:rPr>
+      <w:spacing w:before="240" w:after="200"/>
+    </w:pPr>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading1Char">
+    <w:rPr/>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading2">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="32"/>
+      </w:rPr>
+      <w:spacing w:before="200" w:after="160"/>
+    </w:pPr>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading2Char">
+    <w:rPr/>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading3">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="28"/>
+      </w:rPr>
+      <w:spacing w:before="160" w:after="120"/>
+    </w:pPr>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading3Char">
+    <w:rPr/>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading4">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="24"/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading4Char">
+    <w:rPr/>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading5">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="22"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading5Char">
+    <w:rPr/>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading6">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading6Char">
+    <w:rPr/>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:latentStyles/>
+</w:styles>
+############################## word/document.xml ##############################
+<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:tbl>
+      <w:tblPr>
+        <w:tblCellMar>
+          <w:top w:w="0"/>
+          <w:bottom w:w="0"/>
+          <w:start w:w="30"/>
+          <w:end w:w="30"/>
+        </w:tblCellMar>
+        <w:tblCellSpacing w:w="20"/>
+      </w:tblPr>
+      <w:tr>
+        <w:trPr>
+          <w:tblHeader/>
+        </w:trPr>
+        <w:tc>
+          <w:tcPr>
+            <w:tcBorders>
+              <w:bottom w:val="single" w:color="auto" w:sz="8"/>
+              <w:end w:val="none" w:color="auto" w:sz="8"/>
+              <w:start w:val="none" w:color="auto" w:sz="8"/>
+            </w:tcBorders>
+            <w:gridSpan w:val="7"/>
+            <w:hideMark/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr/>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr>
+          <w:tblHeader/>
+        </w:trPr>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b/>
+              </w:rPr>
+              <w:t>No</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b/>
+              </w:rPr>
+              <w:t>Variable</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b/>
+              </w:rPr>
+              <w:t>Stats / Values</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b/>
+              </w:rPr>
+              <w:t>Freqs (% of Valid)</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b/>
+              </w:rPr>
+              <w:t>Graph</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b/>
+              </w:rPr>
+              <w:t>Valid</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="top"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr>
+                <w:b/>
+              </w:rPr>
+              <w:t>Missing</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr>
+          <w:tblHeader/>
+        </w:trPr>
+        <w:tc>
+          <w:tcPr>
+            <w:tcBorders>
+              <w:bottom w:val="single" w:color="auto" w:sz="4"/>
+              <w:end w:val="none" w:color="auto" w:sz="4"/>
+              <w:start w:val="none" w:color="auto" w:sz="4"/>
+            </w:tcBorders>
+            <w:gridSpan w:val="7"/>
+            <w:hideMark/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr/>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr/>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:t>1</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:t>floatmissing</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:br w:type="textWrapping"/>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>[Float64?]</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:drawing>
+                <wp:inline>
+                  <wp:extent cx="1320800" cy="12700"/>
+                  <wp:docPr id="2" name="Picture 2"/>
+                  <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                    <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                        <pic:nvPicPr>
+                          <pic:cNvPr id="2" name="Picture 2"/>
+                          <pic:cNvPicPr/>
+                        </pic:nvPicPr>
+                        <pic:blipFill>
+                          <a:blip>
+                            <a:extLst>
+                              <a:ext uri="{28A0092B-C50C-407E-A947-70E740481C1C}"/>
+                              <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">
+                                <asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="rId2"/>
+                              </a:ext>
+                            </a:extLst>
+                          </a:blip>
+                          <a:stretch>
+                            <a:fillRect/>
+                          </a:stretch>
+                        </pic:blipFill>
+                        <pic:spPr>
+                          <a:xfrm>
+                            <a:off x="0" y="0"/>
+                            <a:ext cx="1320800" cy="12700"/>
+                          </a:xfrm>
+                          <a:prstGeom prst="rect">
+                            <a:avLst/>
+                          </a:prstGeom>
+                        </pic:spPr>
+                      </pic:pic>
+                    </a:graphicData>
+                  </a:graphic>
+                </wp:inline>
+              </w:drawing>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:t>0</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:br w:type="textWrapping"/>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>(</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>0</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>%)</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+              <w:bottom w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:t>3</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:br w:type="textWrapping"/>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>(</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>100</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>%)</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr/>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:t>2</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:t>justmissing</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:br w:type="textWrapping"/>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>[Missing]</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:drawing>
+                <wp:inline>
+                  <wp:extent cx="1320800" cy="12700"/>
+                  <wp:docPr id="3" name="Picture 3"/>
+                  <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                    <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                        <pic:nvPicPr>
+                          <pic:cNvPr id="3" name="Picture 3"/>
+                          <pic:cNvPicPr/>
+                        </pic:nvPicPr>
+                        <pic:blipFill>
+                          <a:blip>
+                            <a:extLst>
+                              <a:ext uri="{28A0092B-C50C-407E-A947-70E740481C1C}"/>
+                              <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">
+                                <asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="rId3"/>
+                              </a:ext>
+                            </a:extLst>
+                          </a:blip>
+                          <a:stretch>
+                            <a:fillRect/>
+                          </a:stretch>
+                        </pic:blipFill>
+                        <pic:spPr>
+                          <a:xfrm>
+                            <a:off x="0" y="0"/>
+                            <a:ext cx="1320800" cy="12700"/>
+                          </a:xfrm>
+                          <a:prstGeom prst="rect">
+                            <a:avLst/>
+                          </a:prstGeom>
+                        </pic:spPr>
+                      </pic:pic>
+                    </a:graphicData>
+                  </a:graphic>
+                </wp:inline>
+              </w:drawing>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:t>0</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:br w:type="textWrapping"/>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>(</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>0</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>%)</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr>
+            <w:tcMar>
+              <w:top w:w="60"/>
+            </w:tcMar>
+            <w:vAlign w:val="center"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr>
+              <w:jc w:val="start"/>
+            </w:pPr>
+            <w:r>
+              <w:rPr/>
+              <w:t>3</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:br w:type="textWrapping"/>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>(</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>100</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:t>%)</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr/>
+        <w:tc>
+          <w:tcPr>
+            <w:tcBorders>
+              <w:bottom w:val="single" w:color="auto" w:sz="8"/>
+              <w:end w:val="none" w:color="auto" w:sz="8"/>
+              <w:start w:val="none" w:color="auto" w:sz="8"/>
+            </w:tcBorders>
+            <w:gridSpan w:val="7"/>
+            <w:hideMark/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr/>
+          </w:p>
+        </w:tc>
+      </w:tr>
+      <w:tr>
+        <w:trPr/>
+        <w:tc>
+          <w:tcPr>
+            <w:gridSpan w:val="7"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr/>
+            <w:r>
+              <w:rPr>
+                <w:sz w:val="16"/>
+              </w:rPr>
+              <w:t>Dimensions: 3 x 2</w:t>
+            </w:r>
+            <w:r>
+              <w:rPr/>
+              <w:br w:type="textWrapping"/>
+            </w:r>
+            <w:r>
+              <w:rPr>
+                <w:sz w:val="16"/>
+              </w:rPr>
+              <w:t>Duplicate rows: 2</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+      </w:tr>
+    </w:tbl>
+    <w:sectPr/>
+  </w:body>
+</w:document>
+############################## word/media/image_2.svg ##############################
+<svg width='104.0' height='1.0' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 104.0 1.0'></svg>############################## word/media/image_3.svg ##############################
+<svg width='104.0' height='1.0' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 104.0 1.0'></svg>

--- a/test/references/overview_table/only_missings.latex.txt
+++ b/test/references/overview_table/only_missings.latex.txt
@@ -1,0 +1,27 @@
+\documentclass{article}
+\usepackage{threeparttable}
+\usepackage{multirow}
+\usepackage{booktabs}
+\usepackage{xcolor}
+\usepackage{tikz}
+\begin{document}
+\begin{table}[!ht]
+\setlength\tabcolsep{0pt}
+\centering
+\begin{threeparttable}
+\begin{tabular}{@{\extracolsep{2ex}}*{7}{lllllll}}
+\toprule
+\textbf{No} & \textbf{Variable} & \textbf{Stats / Values} & \textbf{Freqs (\% of Valid)} & \textbf{Graph} & \textbf{Valid} & \textbf{Missing} \\[6.0pt]
+\midrule
+1 & \begin{tabular}{@{}c@{}}floatmissing \\ \char`[Float64?]\end{tabular} & \begin{tabular}{@{}c@{}}\end{tabular} & \begin{tabular}{@{}c@{}}\end{tabular} & \raisebox{-.5\height}{\begin{tikzpicture}\end{tikzpicture}} & \begin{tabular}{@{}c@{}}0 \\ (0\%)\end{tabular} & \begin{tabular}{@{}c@{}}3 \\ (100\%)\end{tabular} \\[6.0pt]
+2 & \begin{tabular}{@{}c@{}}justmissing \\ \char`[Missing]\end{tabular} & \begin{tabular}{@{}c@{}}\end{tabular} & \begin{tabular}{@{}c@{}}\end{tabular} & \raisebox{-.5\height}{\begin{tikzpicture}\end{tikzpicture}} & \begin{tabular}{@{}c@{}}0 \\ (0\%)\end{tabular} & \begin{tabular}{@{}c@{}}3 \\ (100\%)\end{tabular} \\
+\bottomrule
+\end{tabular}
+\begin{tablenotes}[flushleft]
+\footnotesize
+\item[]Dimensions: 3 x 2
+\item[]Duplicate rows: 2
+\end{tablenotes}
+\end{threeparttable}
+\end{table}
+\end{document}

--- a/test/references/overview_table/only_missings.txt
+++ b/test/references/overview_table/only_missings.txt
@@ -1,0 +1,62 @@
+<table id="st-4c6fe20d">
+    <style>
+        #st-4c6fe20d {
+            border: none;
+            margin: 0 auto;
+            padding: 0.25rem;
+            border-collapse: separate;
+            border-spacing: 0.85em 0.2em;
+            line-height: 1.2em;
+        }
+        #st-4c6fe20d tr {
+            background-color: transparent;
+            border: none;
+        }
+        #st-4c6fe20d tr td {
+            vertical-align: top;
+            padding: 0;
+            border: none;
+            background-color: transparent;
+        }
+        #st-4c6fe20d br {
+            line-height: 0em;
+            margin: 0;
+        }
+        #st-4c6fe20d sub {
+            line-height: 0;
+        }
+        #st-4c6fe20d sup {
+            line-height: 0;
+        }
+    </style>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
+    <tr>
+        <td style="font-weight:bold;padding-bottom: 3.0pt;text-align:left;">No</td>
+        <td style="font-weight:bold;padding-bottom: 3.0pt;text-align:left;">Variable</td>
+        <td style="font-weight:bold;padding-bottom: 3.0pt;text-align:left;">Stats / Values</td>
+        <td style="font-weight:bold;padding-bottom: 3.0pt;text-align:left;">Freqs (% of Valid)</td>
+        <td style="font-weight:bold;padding-bottom: 3.0pt;text-align:left;">Graph</td>
+        <td style="font-weight:bold;padding-bottom: 3.0pt;text-align:left;">Valid</td>
+        <td style="font-weight:bold;padding-bottom: 3.0pt;text-align:left;">Missing</td>
+    </tr>
+        <tr><td colspan="7" style="border-bottom:1px solid currentColor;padding:0"></td></tr>    <tr>
+        <td style="padding-bottom: 3.0pt;padding-top: 3.0pt;vertical-align:middle;text-align:left;">1</td>
+        <td style="padding-bottom: 3.0pt;padding-top: 3.0pt;vertical-align:middle;text-align:left;">floatmissing<br>[Float64?]</td>
+        <td style="padding-bottom: 3.0pt;padding-top: 3.0pt;vertical-align:middle;text-align:left;"></td>
+        <td style="padding-bottom: 3.0pt;padding-top: 3.0pt;vertical-align:middle;text-align:left;"></td>
+        <td style="padding-bottom: 3.0pt;padding-top: 3.0pt;vertical-align:middle;text-align:left;"><svg width='104.0' height='1.0' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 104.0 1.0'></svg></td>
+        <td style="padding-bottom: 3.0pt;padding-top: 3.0pt;vertical-align:middle;text-align:left;">0<br>(0%)</td>
+        <td style="padding-bottom: 3.0pt;padding-top: 3.0pt;vertical-align:middle;text-align:left;">3<br>(100%)</td>
+    </tr>
+    <tr>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">2</td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">justmissing<br>[Missing]</td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"></td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"></td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><svg width='104.0' height='1.0' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 104.0 1.0'></svg></td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">0<br>(0%)</td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">3<br>(100%)</td>
+    </tr>
+    <tr><td colspan="7" style="border-bottom: 1.5px solid currentColor; padding: 0"></td></tr>
+    <tr><td colspan="7" style="font-size: 0.8em;">Dimensions: 3 x 2<br/>Duplicate rows: 2</td></tr>
+</table>

--- a/test/references/overview_table/only_missings.typ.txt
+++ b/test/references/overview_table/only_missings.typ.txt
@@ -1,0 +1,38 @@
+
+#table(
+    rows: 3,
+    columns: 7,
+    column-gutter: 0.25em,
+    align: (left, left, left, left, left, left, left),
+    stroke: none,
+    table.header(
+        table.hline(y: 0, stroke: 1pt),
+        [*No*],
+        [*Variable*],
+        [*Stats / Values*],
+        [*Freqs (% of Valid)*],
+        [*Graph*],
+        [*Valid*],
+        [*Missing*],
+        table.hline(y: 1, stroke: 0.75pt),
+    ),
+    table.cell(align: horizon)[1],
+    table.cell(align: horizon)[floatmissing #linebreak() [Float64?]],
+    table.cell(align: horizon)[],
+    table.cell(align: horizon)[],
+    table.cell(align: horizon)[#image.decode("<svg width='104.0' height='1.0' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 104.0 1.0'></svg>")],
+    table.cell(align: horizon)[0 #linebreak() (0%)],
+    table.cell(align: horizon)[3 #linebreak() (100%)],
+    table.cell(align: horizon)[2],
+    table.cell(align: horizon)[justmissing #linebreak() [Missing]],
+    table.cell(align: horizon)[],
+    table.cell(align: horizon)[],
+    table.cell(align: horizon)[#image.decode("<svg width='104.0' height='1.0' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 104.0 1.0'></svg>")],
+    table.cell(align: horizon)[0 #linebreak() (0%)],
+    table.cell(align: horizon)[3 #linebreak() (100%)],
+    table.hline(y: 3, stroke: 1pt),
+    table.cell(colspan: 7)[#text(size: 0.8em)[
+        Dimensions: 3 x 2\
+        Duplicate rows: 2
+    ]],
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -487,6 +487,10 @@ end
 
             t = overview_table(_df; label_metadata_key = "other_label")
             reftest(t, "references/overview_table/other_label_metadata_key")
+
+            _df_mis = DataFrame(floatmissing = Union{Float64,Missing}[missing, missing, missing], justmissing = [missing, missing, missing])
+            t = overview_table(_df_mis)
+            reftest(t, "references/overview_table/only_missings")
         end
 
         @testset "annotations" begin


### PR DESCRIPTION
Fixes #90 

```julia
_df_mis = DataFrame(
    floatmissing = Union{Float64,Missing}[missing, missing, missing],
    justmissing = [missing, missing, missing]
)
t = overview_table(_df_mis)
```

<img width="559" alt="image" src="https://github.com/user-attachments/assets/d88ff0e2-47ba-4795-bd56-f26bf877ee8a" />
