### PR TITLE
Tables with row groups

### DIFF
--- a/src/SummaryTables.jl
+++ b/src/SummaryTables.jl
@@ -39,6 +39,7 @@ export overview_table
 export table_one
 export listingtable
 export summarytable
+export rowgroup_table
 export Cell
 export CellStyle
 export Table
@@ -64,6 +65,7 @@ include("table_functions/overview_table.jl")
 include("table_functions/table_one.jl")
 include("table_functions/listingtable.jl")
 include("table_functions/summarytable.jl")
+include("table_functions/rowgroup_table.jl")
 
 include("renderers/utils.jl")
 include("renderers/latex.jl")

--- a/src/table_functions/rowgroup_table.jl
+++ b/src/table_functions/rowgroup_table.jl
@@ -1,0 +1,44 @@
+function find_rowgroup_labels(x::AbstractVector{<:AbstractString})
+    labels = Pair{Int, String}[]
+    prev = first(x)
+    push!(labels, 1 => prev)
+    for (i, x_i) in enumerate(x)
+        if prev != x_i
+            push!(labels, i => x_i)
+        end
+        prev = x_i
+    end
+    return Dict(labels)
+end
+
+function rowgroup_table(table, rowgroup_col; halign = :left)
+    df = DataFrames.DataFrame(table)
+    rowgroup_labels = find_rowgroup_labels(string.(getproperty(df, rowgroup_col)))
+    select!(df, Not(rowgroup_col))
+
+    body = Matrix{Cell}(undef, size(df, 1) + length(rowgroup_labels), size(df, 2))
+    for j in axes(df, 2)
+        offset = 0
+        indent_pt = j == 1 ? 12 : 0
+        for i in axes(df, 1)
+            bold = i in keys(rowgroup_labels) && j == 1
+            if i in keys(rowgroup_labels)
+                if j != 1
+                    body[i + offset, j] = Cell(nothing)
+                    body[i + offset + 1, j] = Cell(df[i, j]; halign, indent_pt)
+                else
+                    body[i + offset, j] = Cell(rowgroup_labels[i]; halign, bold)
+                    body[i + offset + 1, j] = Cell(df[i, j]; halign, indent_pt)
+                end
+                offset += 1
+            else
+                body[i + offset, j] = Cell(df[i, j]; halign, indent_pt)
+            end
+        end
+    end
+
+    header = [Cell(x; bold = true, halign) for x in names(df)]
+    cells = [header'; body]
+    return Table(cells; header = 1)
+end
+


### PR DESCRIPTION
Hi,

Thank you for this excellent package!

I often have to work with data that has subgroups nested in several groups. In tables I typically represent that with row groups (I'm taking this term from gt's "nomenclature" https://gt.rstudio.com/).

I've written a simple function to take care of this and was wondering if having such a feature as part of SummaryTables.jl would generally be of interest. 

This draft is missing tests and support for a lot of keywords, but I'm happy to add those.

```julia
using DataFrames, SummaryTables

data = DataFrame(
    group=repeat(["group x", "group y", "group z"], inner=2),
    subgroup=repeat(["subgroup x", "subgroup y"], outer=3),
    a=collect(1:6),
    b=reverse(collect(1:6)),
)

rowgroup_table(data, :group)
```

I personally don't like leaving the `subgroup` column header in, so I would call `rename(df, :subgroup => "")` before, but I've omitted that here.

<img width="139" height="207" alt="image" src="https://github.com/user-attachments/assets/af66ab30-0e5a-4a60-a0f8-9af69bfdbe8d" />