### PR TITLE
docs(defaults): Fix annotation_labels variant names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Corrected the `annotation_labels` docstring which listed the nonexistent `:lowercase` and `:uppercase` variants instead of `:letters_lower` and `:letters_upper` [#137](https://github.com/PumasAI/SummaryTables.jl/pull/137).
+
 ## 3.5.1 - 2026-10-23
 
 - Corrected the docstring of `table_one` which erroneously listed `show_testnames` and not `show_tests` [#126](https://github.com/PumasAI/SummaryTables.jl/pull/126).

--- a/src/infrastructure/defaults.jl
+++ b/src/infrastructure/defaults.jl
@@ -18,7 +18,7 @@ Base.@kwdef struct Defaults <: AbstractDefaults
     trailing_zeros::Bool = false
     "If `true`, each footnote is displayed on a separate line."
     linebreak_footnotes::Bool = true
-    "An indexable collection or a `Symbol` that specifies a predefined collection which contains annotation labels. Predefined variants are `:numbers`, `:lowercase`, `:uppercase`, `:roman_lower` and `:roman_upper`."
+    "An indexable collection or a `Symbol` that specifies a predefined collection which contains annotation labels. Predefined variants are `:numbers`, `:letters_lower`, `:letters_upper`, `:roman_lower` and `:roman_upper`."
     annotation_labels = :numbers
     "Key to look up column label metadata with. A value of `nothing` disables lookup."
     label_key::Union{Nothing,String} = "label"


### PR DESCRIPTION
Fixes #130

The `annotation_labels` docstring listed `:lowercase` and `:uppercase` as predefined variants, but those raise an error. The valid symbols are `:letters_lower` and `:letters_upper`.
