### PR TITLE
typst: do not open a header block for `header = 0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `Table(cells; header = 0)` rendering Typst with an unclosed `table.header(`, which made the output fail to compile.
+
 ## 3.6.0 - 2026-08-06
 
 - The category bars in `overview_table`'s HTML, typst and latex output now line up with the corresponding text lines [#149](https://github.com/PumasAI/SummaryTables.jl/pull/149).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed `Table(cells; header = 0)` rendering Typst with an unclosed `table.header(`, which made the output fail to compile.
+- Fixed `Table(cells; header = 0)` rendering Typst with an unclosed `table.header(`, which made the output fail to compile [#151](https://github.com/PumasAI/SummaryTables.jl/pull/151).
 
 ## 3.6.0 - 2026-08-06
 

--- a/src/renderers/typst.jl
+++ b/src/renderers/typst.jl
@@ -47,7 +47,10 @@ function Base.show(io::IO, M::MIME"text/typst", ct::Table)
     indentprint(level, args...) = print(io, "    " ^ level, args...)
     indentprintln(level, args...) = indentprint(level, args..., "\n")
     
-    if ct.header !== nothing
+    # `header = 0` means no header rows, which is how the `row <= ct.header` check
+    # below already treats it. Opening the block here for `header = 0` left it
+    # unclosed, because it is closed on `row == ct.header` and `row` starts at 1.
+    if ct.header !== nothing && ct.header > 0
         print(io, "    table.header(\n    ")
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -891,6 +891,16 @@ end
                     tbl = Table([Cell("[");;])
                     reftest(tbl, "references/typst/open_square_bracket")
                 end
+
+                @testset "header = 0 emits no header block" begin
+                    # `header = 0` used to open a `table.header(` that was never
+                    # closed, so the body cells were parsed as part of the header
+                    # and `#table(` was left open, which Typst rejects.
+                    tbl = Table([Cell("a") Cell("b"); Cell(1) Cell(2)]; header = 0)
+                    s = repr("text/typst", tbl)
+                    @test !occursin("table.header(", s)
+                    @test count(==('('), s) == count(==(')'), s)
+                end
             end
         end
     end


### PR DESCRIPTION
`Table(cells; header = 0)` rendered Typst with an unclosed `table.header(`. Every body
cell was then parsed as part of the header, `#table(` was left open, and the document
failed to compile with `error: unclosed delimiter` — reported against the `#table(` line,
which is misleading, since the table body itself is well formed.

## Reproducing

Found while rendering QMD to typst, where a table ended up with `header = 0`. Any table does
it:

```julia
using SummaryTables

cells = [Cell("a") Cell("b"); Cell(1) Cell(2)]
Table(cells; header = 0)
```

`header = 0` is accepted without complaint — nothing validates it — and HTML, LaTeX and DOCX
all render it as "no header". Typst is the only format where it breaks, and it breaks at
compile time with `error: unclosed delimiter` pointing at `#table(`, which says nothing about
`header`. So an accepted keyword value turns into invalid output in one format only, with a
diagnostic that points somewhere else entirely.

Before this PR, `repr("text/typst", Table(cells; header = 0))` emitted the following — note
that `table.header(` is opened and never closed, so the body cells end up inside the header
and `#table(` is left hanging:

```typst
#table(
    rows: 2,
    columns: 2,
    column-gutter: 0.25em,
    align: (center, center),
    stroke: none,
    table.header(
        table.hline(y: 0, stroke: 1pt),
    [#"a"],
    [#"b"],
    [#"1"],
    [#"2"],
    table.hline(y: 2, stroke: 1pt),
)
```

Parenthesis balance is `+1`. With this PR the same call emits no `table.header(` at all, and
is byte-identical to `header = nothing`.

## Root cause

In `src/renderers/typst.jl`, the header block was opened on `ct.header !== nothing`, which
`0` satisfies, but it is closed on `row == ct.header`, which never holds because `row`
starts at 1. The `row <= ct.header` check that controls indentation already treats `0` as
"no header rows", so the opening site was the one out of step.

## Fix

```julia
-    if ct.header !== nothing
+    if ct.header !== nothing && ct.header > 0
```

## Is `header = 0` even meaningful?

Fair question, since the docstring defines `header` as "the index of the last row of the
header, `nothing` if no header is specified" — so `0` is not a documented value, and
nothing validates it. There were two ways to fix this, and the existing behaviour of the
other renderers decides it:

```julia
cells = [Cell("a") Cell("b"); Cell(1) Cell(2)]
for mime in ("text/html", "text/latex", "text/typst")
    println(mime, "  ", repr(mime, Table(cells; header = 0)) == repr(mime, Table(cells; header = nothing)))
end
# text/html   true
# text/latex  true
# text/typst  true   <- with this fix; before it produced invalid output
```

HTML and LaTeX already treated `header = 0` as "no header", as did the Typst renderer's own
indentation logic. So Typst was the sole outlier, and this change makes it consistent rather
than inventing a new meaning.

`0` also has a use: it suppresses the automatic header separator, which for a table whose header
cells carry `border_bottom = true` is otherwise drawn on top of the cells' own rules. There is
no other keyword for that today.

The alternative fix — rejecting `0` with an `ArgumentError` — would be defensible, but it
breaks code that currently works in three of the four output formats and removes that use with
no replacement, so it seemed wrong to fold into a bugfix. Happy to do it that way instead if
you'd prefer `header` to be strict.

The same guard also fixes negative values: `header = -1` previously produced the identical
unclosed-delimiter output and now renders as "no header" too.

## Test added

A `"header = 0 emits no header block"` testset in the existing `"typst specific"` block
asserts that no `table.header(` is emitted and that parentheses balance. Run against the
unfixed renderer it fails **both** assertions — the balance check reports `Evaluated: 5 == 4`,
the one unmatched `(` — so it is a genuine regression test rather than one that passes either
way.

A reference test would have caught this too, since the suite compiles every Typst reference
with `typst_jll`; there simply was no `header = 0` case among the 135 of them.

## Verification

Full suite on this branch, Julia 1.10.11:

```
Test Summary: | Pass  Total     Time
SummaryTables | 1165   1165  3m34.9s
auto rounding |   17     17
Formatted float strings |   29     29
Trailing zeros per mode |   10     10
Exponent thresholds     |   21     21
NumberFormat            |   58     58
QuartoNotebookRunner/typst |  1      1
Defaults      |   15     15
     Testing SummaryTables tests passed
```

**1316 passed, 0 failed, 0 errored, 0 broken.**

No reference file was regenerated — the working tree is clean after the run, so none of the
Typst, LaTeX, DOCX or plain references changed. `header = 0` output is now byte-identical to
`header = nothing` (both 234 bytes on the 2×2 `cells` used in the section above); against the unfixed renderer the
`header = 0` output was 22 bytes longer with a parenthesis balance of +1, and
`"    table.header(\n    "` is exactly those 22 bytes — so the defect was precisely that one
unmatched insertion.
