### PR TITLE
fix(html): Size overview category bar rows with lh so they track the effective line-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.1 - 2026-08-07
+
+- Fixed misalignment of `overview_table` category bars in HTML output when the environment overrides the table's line-height [#152](https://github.com/PumasAI/SummaryTables.jl/pull/152).
+
 ## 3.6.0 - 2026-08-06
 
 - The category bars in `overview_table`'s HTML, typst and latex output now line up with the corresponding text lines [#149](https://github.com/PumasAI/SummaryTables.jl/pull/149).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SummaryTables"
 uuid = "6ce4ecf0-73a7-4ce3-9fb4-80ebfe887b60"
 authors = ["Julius <juliusk@pumas.ai>", "Mike <michael@pumas.ai>"]
-version = "3.6.0"
+version = "3.6.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/renderers/html.jl
+++ b/src/renderers/html.jl
@@ -321,12 +321,14 @@ function _showas(io::IO, ::MIME"text/html", r::RectPlot)
 end
 
 # each bar occupies one line box of the table's line-height, so the bars
-# align with the corresponding text lines of the neighboring cells
+# align with the corresponding text lines of the neighboring cells; 1lh tracks
+# the line-height even if the environment overrides it, with a static fallback
+# for browsers that don't support the unit
 function _showas(io::IO, ::MIME"text/html", c::CatFreqPlot)
     print(io, "<div style=\"width:6.25em;\">")
     for fraction in c.fractions
         width_percent = round(fraction * 100, digits = 2)
-        print(io, "<div style=\"height:$(HTML_LINE_HEIGHT);display:flex;align-items:center;\">")
+        print(io, "<div style=\"height:$(HTML_LINE_HEIGHT);height:1lh;display:flex;align-items:center;\">")
         print(io, "<div style=\"width:$(width_percent)%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;\"></div>")
         print(io, "</div>")
     end

--- a/test/references/overview_table/basic.txt
+++ b/test/references/overview_table/basic.txt
@@ -1,6 +1,6 @@
-<table id="st-f3ddc0cd">
+<table id="st-2bc8587a">
     <style>
-        #st-f3ddc0cd {
+        #st-2bc8587a {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -8,24 +8,24 @@
             border-spacing: 0.85em 0.2em;
             line-height: 1.2em;
         }
-        #st-f3ddc0cd tr {
+        #st-2bc8587a tr {
             background-color: transparent;
             border: none;
         }
-        #st-f3ddc0cd tr td {
+        #st-2bc8587a tr td {
             vertical-align: top;
             padding: 0;
             border: none;
             background-color: transparent;
         }
-        #st-f3ddc0cd br {
+        #st-2bc8587a br {
             line-height: 0em;
             margin: 0;
         }
-        #st-f3ddc0cd sub {
+        #st-2bc8587a sub {
             line-height: 0;
         }
-        #st-f3ddc0cd sup {
+        #st-2bc8587a sup {
             line-height: 0;
         }
     </style>
@@ -53,7 +53,7 @@
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">categorical<br>[String?]</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">1. C<br>2. A<br>3. B</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">40 (40%)<br>35 (35%)<br>25 (25%)</td>
-        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;display:flex;align-items:center;"><div style="width:40.0%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:35.0%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:25.0%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:40.0%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:35.0%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:25.0%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">100<br>(99%)</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">1<br>(1%)</td>
     </tr>

--- a/test/references/overview_table/categories_exceeded.txt
+++ b/test/references/overview_table/categories_exceeded.txt
@@ -1,6 +1,6 @@
-<table id="st-e346cb23">
+<table id="st-3b03f244">
     <style>
-        #st-e346cb23 {
+        #st-3b03f244 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -8,24 +8,24 @@
             border-spacing: 0.85em 0.2em;
             line-height: 1.2em;
         }
-        #st-e346cb23 tr {
+        #st-3b03f244 tr {
             background-color: transparent;
             border: none;
         }
-        #st-e346cb23 tr td {
+        #st-3b03f244 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
             background-color: transparent;
         }
-        #st-e346cb23 br {
+        #st-3b03f244 br {
             line-height: 0em;
             margin: 0;
         }
-        #st-e346cb23 sub {
+        #st-3b03f244 sub {
             line-height: 0;
         }
-        #st-e346cb23 sup {
+        #st-3b03f244 sup {
             line-height: 0;
         }
     </style>
@@ -44,7 +44,7 @@
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">categorical<br>[String]</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">1. Z<br>2. Y<br>3. X<br>4. W<br>5. V<br>6. U<br>7. T<br>8. S<br>9. R<br>10. Q<br>[16 others]</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">676 (10.9%)<br>625 (10.1%)<br>576 (9.3%)<br>529 (8.5%)<br>484 (7.8%)<br>441 (7.1%)<br>400 (6.5%)<br>361 (5.8%)<br>324 (5.2%)<br>289 (4.7%)<br>1496 (24.1%)</td>
-        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;display:flex;align-items:center;"><div style="width:10.9%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:10.08%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:9.29%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:8.53%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:7.81%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:7.11%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:6.45%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:5.82%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:5.22%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:4.66%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:24.13%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:10.9%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:10.08%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:9.29%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:8.53%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:7.81%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:7.11%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:6.45%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:5.82%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:5.22%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:4.66%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:24.13%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">6201<br>(100%)</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">0<br>(0%)</td>
     </tr>

--- a/test/references/overview_table/default_label_metadata_key.txt
+++ b/test/references/overview_table/default_label_metadata_key.txt
@@ -1,6 +1,6 @@
-<table id="st-06522852">
+<table id="st-a973a7f3">
     <style>
-        #st-06522852 {
+        #st-a973a7f3 {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -8,24 +8,24 @@
             border-spacing: 0.85em 0.2em;
             line-height: 1.2em;
         }
-        #st-06522852 tr {
+        #st-a973a7f3 tr {
             background-color: transparent;
             border: none;
         }
-        #st-06522852 tr td {
+        #st-a973a7f3 tr td {
             vertical-align: top;
             padding: 0;
             border: none;
             background-color: transparent;
         }
-        #st-06522852 br {
+        #st-a973a7f3 br {
             line-height: 0em;
             margin: 0;
         }
-        #st-06522852 sub {
+        #st-a973a7f3 sub {
             line-height: 0;
         }
-        #st-06522852 sup {
+        #st-a973a7f3 sup {
             line-height: 0;
         }
     </style>
@@ -56,7 +56,7 @@
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"></td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">1. B<br>2. A<br>3. C</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">1 (33.3%)<br>1 (33.3%)<br>1 (33.3%)</td>
-        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">3<br>(100%)</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">0<br>(0%)</td>
     </tr>

--- a/test/references/overview_table/max_categories_5.txt
+++ b/test/references/overview_table/max_categories_5.txt
@@ -1,6 +1,6 @@
-<table id="st-5cf7fd79">
+<table id="st-1b87b0fb">
     <style>
-        #st-5cf7fd79 {
+        #st-1b87b0fb {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -8,24 +8,24 @@
             border-spacing: 0.85em 0.2em;
             line-height: 1.2em;
         }
-        #st-5cf7fd79 tr {
+        #st-1b87b0fb tr {
             background-color: transparent;
             border: none;
         }
-        #st-5cf7fd79 tr td {
+        #st-1b87b0fb tr td {
             vertical-align: top;
             padding: 0;
             border: none;
             background-color: transparent;
         }
-        #st-5cf7fd79 br {
+        #st-1b87b0fb br {
             line-height: 0em;
             margin: 0;
         }
-        #st-5cf7fd79 sub {
+        #st-1b87b0fb sub {
             line-height: 0;
         }
-        #st-5cf7fd79 sup {
+        #st-1b87b0fb sup {
             line-height: 0;
         }
     </style>
@@ -44,7 +44,7 @@
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">categorical<br>[String]</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">1. Z<br>2. Y<br>3. X<br>4. W<br>5. V<br>[21 others]</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">676 (10.9%)<br>625 (10.1%)<br>576 (9.3%)<br>529 (8.5%)<br>484 (7.8%)<br>3311 (53.4%)</td>
-        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;display:flex;align-items:center;"><div style="width:10.9%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:10.08%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:9.29%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:8.53%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:7.81%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:53.39%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:10.9%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:10.08%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:9.29%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:8.53%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:7.81%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:53.39%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">6201<br>(100%)</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">0<br>(0%)</td>
     </tr>

--- a/test/references/overview_table/other_label_metadata_key.txt
+++ b/test/references/overview_table/other_label_metadata_key.txt
@@ -1,6 +1,6 @@
-<table id="st-4bac5252">
+<table id="st-2ee1c6af">
     <style>
-        #st-4bac5252 {
+        #st-2ee1c6af {
             border: none;
             margin: 0 auto;
             padding: 0.25rem;
@@ -8,24 +8,24 @@
             border-spacing: 0.85em 0.2em;
             line-height: 1.2em;
         }
-        #st-4bac5252 tr {
+        #st-2ee1c6af tr {
             background-color: transparent;
             border: none;
         }
-        #st-4bac5252 tr td {
+        #st-2ee1c6af tr td {
             vertical-align: top;
             padding: 0;
             border: none;
             background-color: transparent;
         }
-        #st-4bac5252 br {
+        #st-2ee1c6af br {
             line-height: 0em;
             margin: 0;
         }
-        #st-4bac5252 sub {
+        #st-2ee1c6af sub {
             line-height: 0;
         }
-        #st-4bac5252 sup {
+        #st-2ee1c6af sup {
             line-height: 0;
         }
     </style>
@@ -56,7 +56,7 @@
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"></td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">1. B<br>2. A<br>3. C</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">1 (33.3%)<br>1 (33.3%)<br>1 (33.3%)</td>
-        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
+        <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;"><div style="width:6.25em;"><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div><div style="height:1.2em;height:1lh;display:flex;align-items:center;"><div style="width:33.33%;height:0.75em;background-color:lightgray;border:1px solid gray;box-sizing:border-box;"></div></div></div></td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">3<br>(100%)</td>
         <td style="padding-top: 3.0pt;vertical-align:middle;text-align:left;">0<br>(0%)</td>
     </tr>


### PR DESCRIPTION
The category bar rows in `overview_table`'s HTML graph column were fixed to the table's own 1.2em line-height, so in environments whose stylesheets override the cell line-height, the text lines grow but the bars don't, compressing the bar stack. Sizing each bar row with `1lh` makes it track the effective line-height, with the previous 1.2em kept as a fallback for browsers that don't support the unit.

Both screenshots below have `td { line-height: 1.75 }` applied by the page.

## Before

<img width="760" height="400" alt="before" src="https://github.com/user-attachments/assets/5ecd79e9-d036-4f77-9514-41f67b6a49d4">

## After

<img width="760" height="400" alt="after" src="https://github.com/user-attachments/assets/13674af0-f86d-4689-9351-01d5f8900882">
