### PR TITLE
test(docx): Update references for WriteDocx 1.3

### DIFF
--- a/test/references/annotations/annotated_float.docx.txt
+++ b/test/references/annotations/annotated_float.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="1"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="1"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="1"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="1"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/annotations/automatic_annotations.docx.txt
+++ b/test/references/annotations/automatic_annotations.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -290,12 +290,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/annotations/manual_annotations.docx.txt
+++ b/test/references/annotations/manual_annotations.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -290,12 +290,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/character_escaping/problematic_characters.docx.txt
+++ b/test/references/character_escaping/problematic_characters.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="1"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="1"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -218,12 +218,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="1"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="1"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/defaults/annotation_labels_custom.docx.txt
+++ b/test/references/defaults/annotation_labels_custom.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -266,12 +266,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/defaults/annotation_labels_letters_lower.docx.txt
+++ b/test/references/defaults/annotation_labels_letters_lower.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -464,12 +464,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/defaults/annotation_labels_letters_upper.docx.txt
+++ b/test/references/defaults/annotation_labels_letters_upper.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -464,12 +464,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/defaults/annotation_labels_numbers.docx.txt
+++ b/test/references/defaults/annotation_labels_numbers.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -464,12 +464,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/defaults/annotation_labels_roman_lower.docx.txt
+++ b/test/references/defaults/annotation_labels_roman_lower.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -464,12 +464,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/defaults/annotation_labels_roman_upper.docx.txt
+++ b/test/references/defaults/annotation_labels_roman_upper.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -464,12 +464,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/auto_false_1.docx.txt
+++ b/test/references/global_rounding/auto_false_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -335,12 +335,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/auto_false_3.docx.txt
+++ b/test/references/global_rounding/auto_false_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -335,12 +335,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/auto_true_1.docx.txt
+++ b/test/references/global_rounding/auto_true_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -335,12 +335,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/auto_true_3.docx.txt
+++ b/test/references/global_rounding/auto_true_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -335,12 +335,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/default.docx.txt
+++ b/test/references/global_rounding/default.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -335,12 +335,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/digits_false_1.docx.txt
+++ b/test/references/global_rounding/digits_false_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -315,12 +315,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/digits_false_3.docx.txt
+++ b/test/references/global_rounding/digits_false_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -315,12 +315,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/digits_true_1.docx.txt
+++ b/test/references/global_rounding/digits_true_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -315,12 +315,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/digits_true_3.docx.txt
+++ b/test/references/global_rounding/digits_true_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -315,12 +315,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/no_rounding.docx.txt
+++ b/test/references/global_rounding/no_rounding.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -315,12 +315,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/sigdigits_false_1.docx.txt
+++ b/test/references/global_rounding/sigdigits_false_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -365,12 +365,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/sigdigits_false_3.docx.txt
+++ b/test/references/global_rounding/sigdigits_false_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -365,12 +365,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/sigdigits_true_1.docx.txt
+++ b/test/references/global_rounding/sigdigits_true_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -365,12 +365,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/global_rounding/sigdigits_true_3.docx.txt
+++ b/test/references/global_rounding/sigdigits_true_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -365,12 +365,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/cols_only.docx.txt
+++ b/test/references/listingtable/cols_only.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -202,12 +202,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -269,12 +269,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -294,12 +294,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -393,12 +393,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -418,12 +418,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -443,12 +443,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -468,12 +468,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -646,12 +646,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -786,12 +786,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/label_metadata.docx.txt
+++ b/test/references/listingtable/label_metadata.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -329,12 +329,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -442,12 +442,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/label_metadata_override.docx.txt
+++ b/test/references/listingtable/label_metadata_override.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -329,12 +329,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -442,12 +442,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/missing_groups.docx.txt
+++ b/test/references/listingtable/missing_groups.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -344,12 +344,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -550,12 +550,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/natural_sort_order.docx.txt
+++ b/test/references/listingtable/natural_sort_order.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -258,12 +258,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -863,12 +863,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/no_variable_header.docx.txt
+++ b/test/references/listingtable/no_variable_header.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -302,12 +302,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -327,12 +327,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -439,12 +439,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -612,12 +612,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/one_row_two_cols.docx.txt
+++ b/test/references/listingtable/one_row_two_cols.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -302,12 +302,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -327,12 +327,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -473,12 +473,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -646,12 +646,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_cols=1_1.docx.txt
+++ b/test/references/listingtable/pagination_cols=1_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -369,12 +369,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -452,12 +452,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_cols=1_2.docx.txt
+++ b/test/references/listingtable/pagination_cols=1_2.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -369,12 +369,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -452,12 +452,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_cols=1_3.docx.txt
+++ b/test/references/listingtable/pagination_cols=1_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -369,12 +369,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -452,12 +452,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_cols=1_4.docx.txt
+++ b/test/references/listingtable/pagination_cols=1_4.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -369,12 +369,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -452,12 +452,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_cols=2_1.docx.txt
+++ b/test/references/listingtable/pagination_cols=2_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -286,12 +286,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -402,12 +402,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -515,12 +515,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_cols=2_2.docx.txt
+++ b/test/references/listingtable/pagination_cols=2_2.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -286,12 +286,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -402,12 +402,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -515,12 +515,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=1_1.docx.txt
+++ b/test/references/listingtable/pagination_rows=1_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -448,12 +448,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=1_2.docx.txt
+++ b/test/references/listingtable/pagination_rows=1_2.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -448,12 +448,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=1_3.docx.txt
+++ b/test/references/listingtable/pagination_rows=1_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -448,12 +448,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=1_4.docx.txt
+++ b/test/references/listingtable/pagination_rows=1_4.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -448,12 +448,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=1_cols=2_1.docx.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -286,12 +286,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -402,12 +402,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -467,12 +467,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=1_cols=2_2.docx.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_2.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -286,12 +286,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -402,12 +402,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -467,12 +467,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=1_cols=2_3.docx.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -286,12 +286,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -402,12 +402,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -467,12 +467,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=1_cols=2_4.docx.txt
+++ b/test/references/listingtable/pagination_rows=1_cols=2_4.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -286,12 +286,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -402,12 +402,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -467,12 +467,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_1.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -513,12 +513,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_2.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_2.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -513,12 +513,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_summarized_1.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -779,12 +779,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_1.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -403,12 +403,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -736,12 +736,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_2.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_1_2.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -403,12 +403,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -736,12 +736,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_1.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_1.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -586,12 +586,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_2.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_2.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -586,12 +586,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_3.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_3.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -586,12 +586,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_4.docx.txt
+++ b/test/references/listingtable/pagination_rows=2_summarized_grouplevel_2_4.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -586,12 +586,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/renaming.docx.txt
+++ b/test/references/listingtable/renaming.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -779,12 +779,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/rows_only.docx.txt
+++ b/test/references/listingtable/rows_only.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -275,12 +275,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -812,12 +812,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/sort_false.docx.txt
+++ b/test/references/listingtable/sort_false.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -403,12 +403,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -736,12 +736,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/summarize_end_cols_two_funcs.docx.txt
+++ b/test/references/listingtable/summarize_end_cols_two_funcs.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -346,12 +346,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -371,12 +371,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -595,12 +595,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -828,12 +828,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/summarize_end_rows.docx.txt
+++ b/test/references/listingtable/summarize_end_rows.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -718,12 +718,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/summarize_end_rows_two_funcs.docx.txt
+++ b/test/references/listingtable/summarize_end_rows_two_funcs.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -779,12 +779,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/summarize_first_group_cols.docx.txt
+++ b/test/references/listingtable/summarize_first_group_cols.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -249,12 +249,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -371,12 +371,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -407,12 +407,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -638,12 +638,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -871,12 +871,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/summarize_first_group_rows.docx.txt
+++ b/test/references/listingtable/summarize_first_group_rows.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -807,12 +807,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/summarize_last_group_cols.docx.txt
+++ b/test/references/listingtable/summarize_last_group_cols.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="9"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="9"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -856,12 +856,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="9"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="9"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1149,12 +1149,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="9"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="9"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/summarize_last_group_rows.docx.txt
+++ b/test/references/listingtable/summarize_last_group_rows.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -969,12 +969,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/two_rows_one_col.docx.txt
+++ b/test/references/listingtable/two_rows_one_col.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -368,12 +368,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -641,12 +641,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/listingtable/two_same_summarizers.docx.txt
+++ b/test/references/listingtable/two_same_summarizers.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -292,12 +292,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1413,12 +1413,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_false.docx.txt
+++ b/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_false.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -239,12 +239,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_true.docx.txt
+++ b/test/references/manual_footnotes/footnotes_and_annotated_linebreaks_true.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -239,12 +239,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/manual_footnotes/footnotes_linebreaks_false.docx.txt
+++ b/test/references/manual_footnotes/footnotes_linebreaks_false.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -233,12 +233,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/manual_footnotes/footnotes_linebreaks_true.docx.txt
+++ b/test/references/manual_footnotes/footnotes_linebreaks_true.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -233,12 +233,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/merged_cells/custom_datatypes.docx.txt
+++ b/test/references/merged_cells/custom_datatypes.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -317,12 +317,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/number_format/limits.docx.txt
+++ b/test/references/number_format/limits.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -266,12 +266,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/number_format/magnitudes_financial.docx.txt
+++ b/test/references/number_format/magnitudes_financial.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -266,12 +266,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/number_format/magnitudes_si.docx.txt
+++ b/test/references/number_format/magnitudes_si.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -266,12 +266,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/number_format/scale_percent.docx.txt
+++ b/test/references/number_format/scale_percent.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -266,12 +266,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/number_format/x10.docx.txt
+++ b/test/references/number_format/x10.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -286,12 +286,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/overview_table/basic.docx.txt
+++ b/test/references/overview_table/basic.docx.txt
@@ -126,8 +126,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -146,8 +146,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -171,13 +171,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -185,12 +185,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -342,12 +342,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -916,12 +916,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/overview_table/categories_exceeded.docx.txt
+++ b/test/references/overview_table/categories_exceeded.docx.txt
@@ -125,8 +125,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -145,8 +145,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -170,13 +170,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -184,12 +184,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -341,12 +341,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -893,12 +893,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/overview_table/default_label_metadata_key.docx.txt
+++ b/test/references/overview_table/default_label_metadata_key.docx.txt
@@ -126,8 +126,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -146,8 +146,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -171,13 +171,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -185,12 +185,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -361,12 +361,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -970,12 +970,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/overview_table/max_categories_5.docx.txt
+++ b/test/references/overview_table/max_categories_5.docx.txt
@@ -125,8 +125,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -145,8 +145,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -170,13 +170,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -184,12 +184,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -341,12 +341,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -733,12 +733,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/overview_table/only_missings.docx.txt
+++ b/test/references/overview_table/only_missings.docx.txt
@@ -126,8 +126,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -146,8 +146,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -171,13 +171,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -185,12 +185,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -342,12 +342,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -748,12 +748,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/overview_table/other_label_metadata_key.docx.txt
+++ b/test/references/overview_table/other_label_metadata_key.docx.txt
@@ -126,8 +126,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -146,8 +146,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -171,13 +171,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -185,12 +185,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -361,12 +361,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -970,12 +970,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/replace/replace_predicate_function.docx.txt
+++ b/test/references/replace/replace_predicate_function.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -262,12 +262,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/replace/replace_predicate_value.docx.txt
+++ b/test/references/replace/replace_predicate_value.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -262,12 +262,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/replace/replacemissing_custom.docx.txt
+++ b/test/references/replace/replacemissing_custom.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -262,12 +262,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/replace/replacemissing_default.docx.txt
+++ b/test/references/replace/replacemissing_default.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -266,12 +266,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/replace/replacemissing_nested.docx.txt
+++ b/test/references/replace/replacemissing_nested.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -252,15 +252,15 @@
             </w:r>
             <w:r>
               <w:rPr>
-                <w:color w:val="ff0000"/>
                 <w:b/>
+                <w:color w:val="ff0000"/>
               </w:rPr>
               <w:t xml:space="preserve">styled </w:t>
             </w:r>
             <w:r>
               <w:rPr>
-                <w:color w:val="ff0000"/>
                 <w:b/>
+                <w:color w:val="ff0000"/>
               </w:rPr>
               <w:t>-</w:t>
             </w:r>
@@ -304,12 +304,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/row_and_column_gaps/singlecell.docx.txt
+++ b/test/references/row_and_column_gaps/singlecell.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -499,12 +499,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/row_and_column_gaps/spanned_cells.docx.txt
+++ b/test/references/row_and_column_gaps/spanned_cells.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -408,12 +408,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/simple_table/no_args.docx.txt
+++ b/test/references/simple_table/no_args.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -292,12 +292,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -933,12 +933,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/simple_table/three_cols.docx.txt
+++ b/test/references/simple_table/three_cols.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -258,12 +258,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -659,12 +659,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/simple_table/three_cols_halign_left.docx.txt
+++ b/test/references/simple_table/three_cols_halign_left.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -258,12 +258,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -659,12 +659,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/simple_table/three_cols_halign_left_center_right.docx.txt
+++ b/test/references/simple_table/three_cols_halign_left_center_right.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -258,12 +258,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -659,12 +659,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/simple_table/three_cols_subheaders.docx.txt
+++ b/test/references/simple_table/three_cols_subheaders.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -314,12 +314,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -715,12 +715,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/simple_table/three_cols_subheaders_and_haligns.docx.txt
+++ b/test/references/simple_table/three_cols_subheaders_and_haligns.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -314,12 +314,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -715,12 +715,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/simple_table/three_cols_with_names.docx.txt
+++ b/test/references/simple_table/three_cols_with_names.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -251,8 +251,8 @@
             </w:r>
             <w:r>
               <w:rPr>
-                <w:vertAlign w:val="superscript"/>
                 <w:b/>
+                <w:vertAlign w:val="superscript"/>
               </w:rPr>
               <w:t>1</w:t>
             </w:r>
@@ -265,12 +265,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -666,12 +666,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/styled/example.docx.txt
+++ b/test/references/styled/example.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -225,9 +225,9 @@
             </w:r>
             <w:r>
               <w:rPr>
+                <w:b/>
                 <w:color w:val="ffaa00"/>
                 <w:vertAlign w:val="superscript"/>
-                <w:b/>
               </w:rPr>
               <w:t>Orange</w:t>
             </w:r>
@@ -244,9 +244,9 @@
             </w:pPr>
             <w:r>
               <w:rPr>
-                <w:color w:val="00cc00"/>
                 <w:b/>
                 <w:i/>
+                <w:color w:val="00cc00"/>
               </w:rPr>
               <w:t>Green, bold, italic, underlined</w:t>
             </w:r>
@@ -300,12 +300,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -325,9 +325,9 @@
             </w:pPr>
             <w:r>
               <w:rPr>
+                <w:b/>
                 <w:color w:val="ffaa00"/>
                 <w:vertAlign w:val="superscript"/>
-                <w:b/>
               </w:rPr>
               <w:t>Orange</w:t>
             </w:r>
@@ -345,8 +345,8 @@
             </w:r>
             <w:r>
               <w:rPr>
-                <w:sz w:val="16"/>
                 <w:i/>
+                <w:sz w:val="16"/>
               </w:rPr>
               <w:t>italics</w:t>
             </w:r>
@@ -362,8 +362,8 @@
             </w:r>
             <w:r>
               <w:rPr>
-                <w:sz w:val="16"/>
                 <w:b/>
+                <w:sz w:val="16"/>
               </w:rPr>
               <w:t>bold</w:t>
             </w:r>

--- a/test/references/styles/valign.docx.txt
+++ b/test/references/styles/valign.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -398,12 +398,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/column_label_metadata.docx.txt
+++ b/test/references/summarytable/column_label_metadata.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -269,12 +269,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -550,12 +550,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/missing_groups.docx.txt
+++ b/test/references/summarytable/missing_groups.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -377,12 +377,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -634,12 +634,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/natural_sort_order.docx.txt
+++ b/test/references/summarytable/natural_sort_order.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -269,12 +269,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1078,12 +1078,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/no_group_one_summary.docx.txt
+++ b/test/references/summarytable/no_group_one_summary.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -287,12 +287,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/no_group_two_summaries.docx.txt
+++ b/test/references/summarytable/no_group_two_summaries.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -322,12 +322,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/one_rowgroup_one_colgroup_one_summary.docx.txt
+++ b/test/references/summarytable/one_rowgroup_one_colgroup_one_summary.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -362,12 +362,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -509,12 +509,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/one_rowgroup_one_colgroup_two_summaries.docx.txt
+++ b/test/references/summarytable/one_rowgroup_one_colgroup_two_summaries.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -362,12 +362,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -643,12 +643,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/one_rowgroup_one_summary.docx.txt
+++ b/test/references/summarytable/one_rowgroup_one_summary.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -252,12 +252,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -369,12 +369,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/one_rowgroup_two_summaries.docx.txt
+++ b/test/references/summarytable/one_rowgroup_two_summaries.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -252,12 +252,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -473,12 +473,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/sort_false.docx.txt
+++ b/test/references/summarytable/sort_false.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -436,12 +436,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -837,12 +837,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries.docx.txt
+++ b/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -401,12 +401,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1074,12 +1074,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries_no_header.docx.txt
+++ b/test/references/summarytable/two_rowgroups_one_colgroup_two_summaries_no_header.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -345,12 +345,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1018,12 +1018,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/summarytable/two_same_summaries.docx.txt
+++ b/test/references/summarytable/two_same_summaries.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -322,12 +322,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/all_missing_group.docx.txt
+++ b/test/references/table_one/all_missing_group.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -317,12 +317,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -682,12 +682,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/bool_as_categorical.docx.txt
+++ b/test/references/table_one/bool_as_categorical.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -424,12 +424,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/category_with_missing.docx.txt
+++ b/test/references/table_one/category_with_missing.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -317,12 +317,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -791,12 +791,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/col_metadata_labels.docx.txt
+++ b/test/references/table_one/col_metadata_labels.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -510,12 +510,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/custom_analysis_defaults.docx.txt
+++ b/test/references/table_one/custom_analysis_defaults.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -384,12 +384,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/custom_analysis_defaults_vector_of_funcs.docx.txt
+++ b/test/references/table_one/custom_analysis_defaults_vector_of_funcs.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -513,12 +513,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/group_totals_three_groups_one_total_level_three.docx.txt
+++ b/test/references/table_one/group_totals_three_groups_one_total_level_three.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="14"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="14"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="12"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="12"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -351,12 +351,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -376,12 +376,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -551,12 +551,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -576,12 +576,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -601,12 +601,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -626,12 +626,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -975,12 +975,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="14"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="14"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -3277,12 +3277,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="14"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="14"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/group_totals_three_groups_one_total_level_two.docx.txt
+++ b/test/references/table_one/group_totals_three_groups_one_total_level_two.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="12"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="12"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="10"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="10"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -351,12 +351,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -376,12 +376,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -597,12 +597,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -622,12 +622,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -658,12 +658,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -683,12 +683,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -973,12 +973,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="12"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="12"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -2945,12 +2945,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="12"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="12"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/group_totals_two_groups_one_total.docx.txt
+++ b/test/references/table_one/group_totals_two_groups_one_total.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -335,12 +335,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -360,12 +360,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -513,12 +513,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
-            <w:tcBorders>
-              <w:bottom w:val="single" w:color="auto" w:sz="6"/>
-              <w:end w:val="none" w:color="auto" w:sz="6"/>
-              <w:start w:val="none" w:color="auto" w:sz="6"/>
-            </w:tcBorders>
             <w:gridSpan w:val="8"/>
+            <w:tcBorders>
+              <w:bottom w:val="single" w:color="auto" w:sz="6"/>
+              <w:end w:val="none" w:color="auto" w:sz="6"/>
+              <w:start w:val="none" w:color="auto" w:sz="6"/>
+            </w:tcBorders>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1825,12 +1825,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/missing_as_a_group_factor.docx.txt
+++ b/test/references/table_one/missing_as_a_group_factor.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -373,12 +373,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
-            <w:tcBorders>
-              <w:bottom w:val="single" w:color="auto" w:sz="6"/>
-              <w:end w:val="none" w:color="auto" w:sz="6"/>
-              <w:start w:val="none" w:color="auto" w:sz="6"/>
-            </w:tcBorders>
             <w:gridSpan w:val="3"/>
+            <w:tcBorders>
+              <w:bottom w:val="single" w:color="auto" w:sz="6"/>
+              <w:end w:val="none" w:color="auto" w:sz="6"/>
+              <w:start w:val="none" w:color="auto" w:sz="6"/>
+            </w:tcBorders>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -535,12 +535,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
-            <w:tcBorders>
-              <w:bottom w:val="single" w:color="auto" w:sz="6"/>
-              <w:end w:val="none" w:color="auto" w:sz="6"/>
-              <w:start w:val="none" w:color="auto" w:sz="6"/>
-            </w:tcBorders>
             <w:gridSpan w:val="7"/>
+            <w:tcBorders>
+              <w:bottom w:val="single" w:color="auto" w:sz="6"/>
+              <w:end w:val="none" w:color="auto" w:sz="6"/>
+              <w:start w:val="none" w:color="auto" w:sz="6"/>
+            </w:tcBorders>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1050,12 +1050,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/multiple_rows_one_group_pvalues_tests_confints.docx.txt
+++ b/test/references/table_one/multiple_rows_one_group_pvalues_tests_confints.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -401,12 +401,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1674,12 +1674,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/natural_sort_order.docx.txt
+++ b/test/references/table_one/natural_sort_order.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -347,12 +347,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -789,12 +789,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/nested_spans_bad_sort.docx.txt
+++ b/test/references/table_one/nested_spans_bad_sort.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -373,12 +373,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -520,12 +520,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -962,12 +962,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/one_row.docx.txt
+++ b/test/references/table_one/one_row.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -385,12 +385,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/one_row_one_group_nonnormal_pvalues_tests_confints.docx.txt
+++ b/test/references/table_one/one_row_one_group_nonnormal_pvalues_tests_confints.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -401,12 +401,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -808,12 +808,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/one_row_one_group_pvalues_no_tests_or_confints.docx.txt
+++ b/test/references/table_one/one_row_one_group_pvalues_no_tests_or_confints.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -345,12 +345,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -678,12 +678,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/one_row_one_group_pvalues_tests_confints.docx.txt
+++ b/test/references/table_one/one_row_one_group_pvalues_tests_confints.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -401,12 +401,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -808,12 +808,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="7"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="7"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/one_row_renamed.docx.txt
+++ b/test/references/table_one/one_row_renamed.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -385,12 +385,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/one_row_two_groups_pvalues.docx.txt
+++ b/test/references/table_one/one_row_two_groups_pvalues.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -379,12 +379,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -404,12 +404,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -583,12 +583,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1099,12 +1099,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="8"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="8"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/single_arg.docx.txt
+++ b/test/references/table_one/single_arg.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -932,12 +932,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/single_arg_with_groupby.docx.txt
+++ b/test/references/table_one/single_arg_with_groupby.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -317,12 +317,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1479,12 +1479,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/sort_false.docx.txt
+++ b/test/references/table_one/sort_false.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -352,12 +352,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -721,12 +721,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="5"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="5"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/two_rows.docx.txt
+++ b/test/references/table_one/two_rows.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -557,12 +557,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/two_rows_one_group.docx.txt
+++ b/test/references/table_one/two_rows_one_group.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -317,12 +317,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -969,12 +969,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/two_rows_one_group_show_overall_false.docx.txt
+++ b/test/references/table_one/two_rows_one_group_show_overall_false.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -289,12 +289,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -776,12 +776,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/two_rows_one_group_show_total_false.docx.txt
+++ b/test/references/table_one/two_rows_one_group_show_total_false.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -213,12 +213,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -289,12 +289,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -776,12 +776,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="3"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="3"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/two_rows_two_groups.docx.txt
+++ b/test/references/table_one/two_rows_two_groups.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -224,12 +224,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="4"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="4"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -335,12 +335,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -360,12 +360,12 @@
         </w:tc>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -483,12 +483,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -1465,12 +1465,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="6"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="6"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_one/vector_and_function_arguments.docx.txt
+++ b/test/references/table_one/vector_and_function_arguments.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="20"/>
           <w:bottom w:w="20"/>
           <w:start w:w="85"/>
           <w:end w:w="85"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -235,12 +235,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="6"/>
               <w:end w:val="none" w:color="auto" w:sz="6"/>
               <w:start w:val="none" w:color="auto" w:sz="6"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -454,12 +454,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>

--- a/test/references/table_style/custom.docx.txt
+++ b/test/references/table_style/custom.docx.txt
@@ -124,8 +124,8 @@
   <w:style w:type="paragraph" w:styleId="Heading5">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="22"/>
         <w:i/>
+        <w:sz w:val="22"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -144,8 +144,8 @@
   <w:style w:type="paragraph" w:styleId="Heading6">
     <w:pPr>
       <w:rPr>
-        <w:sz w:val="20"/>
         <w:i/>
+        <w:sz w:val="20"/>
       </w:rPr>
       <w:spacing w:before="120" w:after="80"/>
     </w:pPr>
@@ -169,13 +169,13 @@
   <w:body>
     <w:tbl>
       <w:tblPr>
+        <w:tblCellSpacing w:type="dxa" w:w="20"/>
         <w:tblCellMar>
           <w:top w:w="50"/>
           <w:bottom w:w="50"/>
           <w:start w:w="200"/>
           <w:end w:w="200"/>
         </w:tblCellMar>
-        <w:tblCellSpacing w:w="20"/>
       </w:tblPr>
       <w:tr>
         <w:trPr>
@@ -183,12 +183,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="16"/>
               <w:end w:val="none" w:color="auto" w:sz="16"/>
               <w:start w:val="none" w:color="auto" w:sz="16"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -202,12 +202,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="8"/>
               <w:end w:val="none" w:color="auto" w:sz="8"/>
               <w:start w:val="none" w:color="auto" w:sz="8"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:tcMar>
               <w:bottom w:w="40"/>
             </w:tcMar>
@@ -230,12 +230,12 @@
         </w:trPr>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="16"/>
               <w:end w:val="none" w:color="auto" w:sz="16"/>
               <w:start w:val="none" w:color="auto" w:sz="16"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>
@@ -313,12 +313,12 @@
         <w:trPr/>
         <w:tc>
           <w:tcPr>
+            <w:gridSpan w:val="2"/>
             <w:tcBorders>
               <w:bottom w:val="single" w:color="auto" w:sz="16"/>
               <w:end w:val="none" w:color="auto" w:sz="16"/>
               <w:start w:val="none" w:color="auto" w:sz="16"/>
             </w:tcBorders>
-            <w:gridSpan w:val="2"/>
             <w:hideMark/>
           </w:tcPr>
           <w:p>


### PR DESCRIPTION
WriteDocx 1.3 emits the children of `rPr`, `tcPr` and `tblPr` in the order the OOXML schema mandates, and adds `w:type="dxa"` to `w:tblCellSpacing`, so all docx references had to be regenerated.

Nothing else about the generated documents changed. Across all 140 files, the multiset of removed and added lines is identical except for that one attribute:

```
$ diff removed.txt added.txt
2c2
<  140 <w:tblCellSpacing w:w="20"/>
---
>  140 <w:tblCellSpacing w:type="dxa" w:w="20"/>
```

No compat bump, since the package itself works with 1.1 and 1.2 as before, only the references pin 1.3's exact output.
