### PR TITLE
feat(table): Validate header and footer indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `Table` now errors for `header` or `footer` indices that lie outside the table or overlap each other, instead of silently producing broken output [#160](https://github.com/PumasAI/SummaryTables.jl/pull/160).
+
 ## 3.7.1 - 2026-09-04
 
 - Allowed `HypothesisTests` 0.12 [#158](https://github.com/PumasAI/SummaryTables.jl/pull/158).

--- a/src/infrastructure/tables.jl
+++ b/src/infrastructure/tables.jl
@@ -29,6 +29,7 @@ function Table(cells, header, footer;
         footnote_size = default,
         footnote_halign = default,
     )
+    validate_header_footer(size(cells, 1), header, footer)
     defs = defaults()
     _number_format = resolve_number_format(number_format, round_digits, round_mode, trailing_zeros, defs)
     _linebreak_footnotes = fallback(linebreak_footnotes, defs.linebreak_footnotes)
@@ -44,6 +45,18 @@ function Table(cells, header, footer;
     _rowgaps = Pair{Int,Length}[k => to_length(v) for (k, v) in rowgaps]
     _colgaps = Pair{Int,Length}[k => to_length(v) for (k, v) in colgaps]
     Table(cells, header, footer, footnotes, _rowgaps, _colgaps, postprocess, _number_format, _linebreak_footnotes, style)
+end
+
+function validate_header_footer(nrows, header, footer)
+    if header !== nothing && !(1 <= header <= nrows)
+        error("`header` must be the index of the last header row, between 1 and the number of rows ($nrows), or `nothing` if the table has no header. Got $header.")
+    end
+    if footer !== nothing && !(1 <= footer <= nrows)
+        error("`footer` must be the index of the first footer row, between 1 and the number of rows ($nrows), or `nothing` if the table has no footer. Got $footer.")
+    end
+    if header !== nothing && footer !== nothing && footer <= header
+        error("`footer` must be larger than `header`, otherwise header and footer overlap. Got header = $header and footer = $footer.")
+    end
 end
 
 function resolve_number_format(number_format, round_digits, round_mode, trailing_zeros, defs)
@@ -100,7 +113,9 @@ Create a `Table` which can be rendered in multiple formats, such as HTML or LaTe
 
 ## Keyword arguments
 - `header`: The index of the last row of the header, `nothing` if no header is specified.
+  Must be between 1 and the number of rows, and smaller than `footer`.
 - `footer`: The index of the first row of the footer, `nothing` if no footer is specified.
+  Must be between 1 and the number of rows, and larger than `header`.
 - `footnotes`: A vector of objects printed as footnotes that are not derived from `Annotated`
   values and therefore don't get labels with counterparts inside the table.
 - `number_format = NumberFormat()`: A `NumberFormat` that is applied to every floating point

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1323,3 +1323,16 @@ end
     
     @test_throws MethodError SummaryTables.defaults!(a = "a", b = "b")
 end
+
+@testset "header and footer validation" begin
+    cells = [Cell("a") Cell("b"); Cell(1) Cell(2); Cell(3) Cell(4)]
+    @test_throws "Got 0" Table(cells; header = 0)
+    @test_throws "Got -1" Table(cells; header = -1)
+    @test_throws "Got 4" Table(cells; header = 4)
+    @test_throws "Got 0" Table(cells; footer = 0)
+    @test_throws "Got 4" Table(cells; footer = 4)
+    @test_throws "header = 2 and footer = 2" Table(cells; header = 2, footer = 2)
+    @test_throws "header = 2 and footer = 1" Table(cells; header = 2, footer = 1)
+    @test Table(cells; header = 1, footer = 3) isa Table
+    @test Table(cells; header = 3) isa Table
+end


### PR DESCRIPTION
`header` and `footer` were never validated, so nonsensical indices were silently accepted. `Table(cells; header = 0)` for example rendered as "no header" in HTML, LaTeX and DOCX, but produced an unclosed `table.header(` in typst, which then failed to compile with `error: unclosed delimiter` pointing at `#table(`. Indices past the last row or a footer overlapping the header were equally unchecked.

Instead of giving `header = 0` a meaning, this rejects it:

```julia
cells = [Cell("a") Cell("b"); Cell(1) Cell(2)]
Table(cells; header = 0)
# ERROR: `header` must be the index of the last header row, between 1 and the number of rows (2), or `nothing` if the table has no header. Got 0.

Table(cells; header = 2, footer = 2)
# ERROR: `footer` must be larger than `header`, otherwise header and footer overlap. Got header = 2 and footer = 2.
```

Alternative to #151, which fixed the typst output for `header = 0` instead.
